### PR TITLE
Use functional options for NewClient() and NewClientCredentials()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,51 @@ import (
   "github.com/labd/commercetools-go-sdk/service/products"
 )
 
-client, err := commercetools.NewClient(&commercetools.Config{
-  ProjectKey:   "<your-project>",
-  Region:       "https://api.sphere.io",
-  AuthProvider: credentials.NewClientCredentialsProvider(
-    "<clientId>", "<clientSecret>", "manage_project:<your-project>"),
-})
+func main() {
 
-if err != nil {
-  log.Fatal(err)
+  // The NewClient and NewClientCredentialsProvider use functional options for
+  // passing values. When no option is passed it uses the CTP_* environment
+  // variables.
+  client, err := commercetools.NewClient(
+		commercetools.ProjectKey("<project-key>"),
+		commercetools.ApiURL("https://api.sphere.io"),
+		commercetools.Debug(false),
+		commercetools.AuthProvider(
+			credentials.NewClientCredentialsProvider(
+				credentials.ClientID("<client-id>"),
+				credentials.ClientSecret("<client-secret>"),
+				credentials.AuthURL("<auth-url>"),
+				credentials.Scope("manage_project:<project-key>"),
+			),
+    ),
+  )
+
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  svc := products.New(client)
+  product, err := svc.ProductCreate(&products.ProductDraft{
+    Key: "test-product",
+    Name: commercetools.LocalizedString{
+      "nl": "Een test product",
+      "en": "A test product",
+    },
+    ProductType: commercetools.Reference{
+      TypeID: "product-type",
+      ID:     "8750e1fd-f431-481f-9296-967b1e56bf49",
+    },
+    Slug: commercetools.LocalizedString{
+      "nl": "een-test-product",
+      "en": "a-test-product",
+    },
+  }
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  log.Print(product)
 }
-
-svc := products.New(client)
-product, err := svc.ProductCreate(&products.ProductDraft{
-  Key: "test-product",
-  Name: commercetools.LocalizedString{
-    "nl": "Een test product",
-    "en": "A test product",
-  },
-  ProductType: commercetools.Reference{
-    TypeID: "product-type",
-    ID:     "8750e1fd-f431-481f-9296-967b1e56bf49",
-  },
-  Slug: commercetools.LocalizedString{
-    "nl": "een-test-product",
-    "en": "a-test-product",
-  },
-}
-
-log.Print(product)
-
 ```
 
 ## Service implementation

--- a/commercetools/credentials/client.go
+++ b/commercetools/credentials/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -23,12 +24,45 @@ type ClientCredentialsProvider struct {
 }
 
 // TODO: Re-use client ?
-func NewClientCredentialsProvider(clientID, clientSecret, scope, authURL string) AuthProvider {
-	return &ClientCredentialsProvider{
-		clientID:     getConfigValue(clientID, "CTP_CLIENT_ID"),
-		clientSecret: getConfigValue(clientSecret, "CTP_CLIENT_SECRET"),
-		scope:        getConfigValue(scope, "CTP_SCOPES"),
-		authURL:      getConfigValue(authURL, "CTP_AUTH_URL"),
+func NewClientCredentials(options ...func(*ClientCredentialsProvider) error) AuthProvider {
+	provider := &ClientCredentialsProvider{
+		clientID:     os.Getenv("CTP_CLIENT_ID"),
+		clientSecret: os.Getenv("CTP_CLIENT_SECRET"),
+		scope:        os.Getenv("CTP_SCOPES"),
+		authURL:      os.Getenv("CTP_AUTH_URL"),
+	}
+
+	for _, option := range options {
+		option(provider)
+	}
+	return provider
+}
+
+func ClientID(value string) func(*ClientCredentialsProvider) error {
+	return func(c *ClientCredentialsProvider) error {
+		c.clientID = value
+		return nil
+	}
+}
+
+func ClientSecret(value string) func(*ClientCredentialsProvider) error {
+	return func(c *ClientCredentialsProvider) error {
+		c.clientSecret = value
+		return nil
+	}
+}
+
+func Scope(value string) func(*ClientCredentialsProvider) error {
+	return func(c *ClientCredentialsProvider) error {
+		c.scope = value
+		return nil
+	}
+}
+
+func AuthURL(value string) func(*ClientCredentialsProvider) error {
+	return func(c *ClientCredentialsProvider) error {
+		c.authURL = value
+		return nil
 	}
 }
 

--- a/testutil/api.go
+++ b/testutil/api.go
@@ -65,11 +65,12 @@ func MockClient(
 
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 
-	client, err := commercetools.NewClient(&commercetools.Config{
-		ProjectKey:   "unittest",
-		APIURL:       ts.URL,
-		AuthProvider: credentials.NewDummyCredentialsProvider("Bearer unittest"),
-	})
+	client, err := commercetools.NewClient(
+		commercetools.ProjectKey("unittest"),
+		commercetools.ApiURL(ts.URL),
+		commercetools.AuthProvider(
+			credentials.NewDummyCredentialsProvider("Bearer unittest"),
+		))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously an 'input' struct was used for NewClient and a list of args
was used for NewClientCredentials(Provider). Since we use environment
variables as fallback functional options seems like the better way to go
here.