### PR TITLE
removed AttributeDefinitionDraft

### DIFF
--- a/service/producttypes/actions.go
+++ b/service/producttypes/actions.go
@@ -66,7 +66,7 @@ func (ua ChangeDescription) MarshalJSON() ([]byte, error) {
 // AddAttributeDefinition will add an attribute definition to the product type
 // being updated.
 type AddAttributeDefinition struct {
-	Attribute AttributeDefinitionDraft `json:"attribute"`
+	Attribute AttributeDefinition `json:"attribute"`
 }
 
 // MarshalJSON override to add the action value

--- a/service/producttypes/api_test.go
+++ b/service/producttypes/api_test.go
@@ -141,7 +141,7 @@ func TestProductTypeUpdate(t *testing.T) {
 				Version: 3,
 				Actions: commercetools.UpdateActions{
 					&producttypes.AddAttributeDefinition{
-						Attribute: producttypes.AttributeDefinitionDraft{
+						Attribute: producttypes.AttributeDefinition{
 							Type: producttypes.BooleanType{},
 							Name: "attribute",
 							Label: commercetools.LocalizedString{

--- a/service/producttypes/types.go
+++ b/service/producttypes/types.go
@@ -122,58 +122,6 @@ func (a *AttributeDefinition) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// AttributeDefinitionDraft is given as payload for Create Attribute Definition
-// requests.
-type AttributeDefinitionDraft struct {
-	// Describes the type of the attribute.
-	Type AttributeType `json:"type"`
-
-	// The unique name of the attribute used in the API. The name must be
-	// between two and 256 characters long and can contain the ASCII letters A
-	// to Z in lowercase or uppercase, digits, underscores (_) and the
-	// hyphen-minus (-). When using the same name for an attribute in two or
-	// more product types all fields of the AttributeDefinition of this
-	// attribute need to be the same across the product types.
-	Name string `json:"name"`
-
-	// A human-readable label for the attribute.
-	Label commercetools.LocalizedString `json:"label"`
-
-	// Whether the attribute is required to have a value.
-	IsRequired bool `json:"isRequired"`
-
-	// Describes how an attribute or a set of attributes should be validated
-	// across all variants of a product.
-	AttributeConstraint AttributeConstraint `json:"attributeConstraint"`
-
-	// Additional information about the attribute that aids content managers
-	// when setting product details.
-	InputTip commercetools.LocalizedString `json:"inputTip,omitempty"`
-
-	// Provides a visual representation type for this attribute. Only relevant
-	// for text-based attribute types like TextType and LocalizableTextType.
-	InputHint commercetools.TextInputHint `json:"inputHint,omitempty"`
-
-	// Whether the attribute’s values should generally be enabled in product
-	// search. This determines whether the value is stored in products for
-	// matching terms in the context of full-text search queries and can be used
-	// in facets & filters as part of product search queries. The exact features
-	// that are enabled/disabled with this flag depend on the concrete attribute
-	// type and are described there.
-	IsSearchable bool `json:"isSearchable"`
-}
-
-// UnmarshalJSON override to map the attribute definition draft to the
-// corresponding struct.
-func (a *AttributeDefinitionDraft) UnmarshalJSON(data []byte) error {
-	type Alias AttributeDefinitionDraft
-	if err := json.Unmarshal(data, (*Alias)(a)); err != nil {
-		return err
-	}
-	a.Type = attributeTypeMapping(a.Type)
-	return nil
-}
-
 // BooleanType indicates the attribute can store a boolean. Valid values for the
 // attribute are true and false (JSON Boolean).
 type BooleanType struct{}


### PR DESCRIPTION
Signature is the same as AttributeDefinition.
The only difference lies in the name being required, but this isn't enforced in the SDK itself.
To simplify the interface we can just utilize the AttributeDefinition when creating a new attribute
and perform validations in the create/update methods themselve (or leave it as it is right now
and let the commercetool API return an error)