### PR TITLE
Remove omitempty tag from transitions attribute

### DIFF
--- a/commercetools/types_state.go
+++ b/commercetools/types_state.go
@@ -121,7 +121,7 @@ type State struct {
 	LastModifiedBy *LastModifiedBy  `json:"lastModifiedBy,omitempty"`
 	CreatedBy      *CreatedBy       `json:"createdBy,omitempty"`
 	Type           StateTypeEnum    `json:"type"`
-	Transitions    []StateReference `json:"transitions,omitempty"`
+	Transitions    []StateReference `json:"transitions"`
 	Roles          []StateRoleEnum  `json:"roles,omitempty"`
 	Name           *LocalizedString `json:"name,omitempty"`
 	Key            string           `json:"key"`
@@ -189,7 +189,7 @@ func (obj StateChangeTypeAction) MarshalJSON() ([]byte, error) {
 // StateDraft is a standalone struct
 type StateDraft struct {
 	Type        StateTypeEnum             `json:"type"`
-	Transitions []StateResourceIdentifier `json:"transitions,omitempty"`
+	Transitions []StateResourceIdentifier `json:"transitions"`
 	Roles       []StateRoleEnum           `json:"roles,omitempty"`
 	Name        *LocalizedString          `json:"name,omitempty"`
 	Key         string                    `json:"key"`
@@ -293,7 +293,7 @@ func (obj StateSetRolesAction) MarshalJSON() ([]byte, error) {
 
 // StateSetTransitionsAction implements the interface StateUpdateAction
 type StateSetTransitionsAction struct {
-	Transitions []StateResourceIdentifier `json:"transitions,omitempty"`
+	Transitions []StateResourceIdentifier `json:"transitions"`
 }
 
 // MarshalJSON override to set the discriminator value


### PR DESCRIPTION
In CommerceTools there is a difference between an empty array of transitions and null transitions:

- `null` transitions denotes a state that can transition to any other state, no constraints have been defined.
- an empty array of transitions is the opposite, it prevents a state from being transitioned to any other state. Said another way, there are no possible transitions from this state.

Omitempty will prevent empty arrays from being encoded and this in turn prevents us from distinguishing between the two behaviours above. Removing it enables us to define a state with no transitions as previously described.

For anyone who wants more information:
- [CommerceTools state](https://docs.commercetools.com/http-api-projects-states)
- [omitempty tag](https://golang.org/pkg/encoding/json/#Marshal)