### PR TITLE
Add GraphQL interface

### DIFF
--- a/commercetools/client.go
+++ b/commercetools/client.go
@@ -295,6 +295,8 @@ func (c *Client) getResponse(ctx context.Context, method string, url string, par
 		req.URL.RawQuery = params.Encode()
 	}
 
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("User-Agent", c.userAgent)
 
 	if c.logLevel > 0 {

--- a/commercetools/client_graphql.go
+++ b/commercetools/client_graphql.go
@@ -1,0 +1,82 @@
+package commercetools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	mapstructure "github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+type GraphQLQuery struct {
+	client   *Client
+	endpoint string
+	query    string
+	vars     GraphQLVariablesMap
+}
+
+// NewGraphQLQuery creates a new GraphQLQuery object which can be used to
+// execute a GraphQL query
+func (client *Client) NewGraphQLQuery(query string) *GraphQLQuery {
+
+	queryObject := GraphQLQuery{
+		client:   client,
+		endpoint: fmt.Sprintf("%s/%s/graphql", client.url, client.projectKey),
+		query:    query,
+	}
+
+	return &queryObject
+}
+
+// Bind variables to the GraphQL query
+func (gql *GraphQLQuery) Bind(key string, value interface{}) {
+	if gql.vars == nil {
+		gql.vars = make(GraphQLVariablesMap)
+	}
+	gql.vars[key] = value
+}
+
+// Execute the GraphQL query
+func (gql *GraphQLQuery) Execute(respData interface{}) error {
+	var body bytes.Buffer
+
+	requestObj := GraphQLRequest{
+		Query:     gql.query,
+		Variables: &gql.vars,
+	}
+
+	if err := json.NewEncoder(&body).Encode(requestObj); err != nil {
+		return errors.Wrap(err, "encode body")
+	}
+	ctx := context.TODO()
+	resp, err := gql.client.getResponse(ctx, "POST", gql.endpoint, nil, &body)
+	defer resp.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	return gql.processResponse(resp, respData)
+}
+
+func (gql *GraphQLQuery) processResponse(resp *http.Response, dest interface{}) error {
+	body, err := ioutil.ReadAll(resp.Body)
+
+	var output GraphQLResponse
+	err = json.Unmarshal(body, &output)
+	if err != nil {
+		return err
+	}
+
+	if output.Errors != nil {
+		return output.Errors[0]
+	}
+
+	if output.Data != nil {
+		mapstructure.Decode(output.Data, &dest)
+	}
+	return nil
+}


### PR DESCRIPTION
Note that this is a work in progress (missing unittest)

Example usage:
```go
var respData struct {
	Product struct {
		ID      string `json:"id"`
		Version int    `json:"version"`
	} `json:"product"`
}

query := client.NewGraphQLQuery(`
	query ($sku: String!)  {
		product(sku: $sku) {
			id
			version
		}
	}
	`)
query.Bind("sku", "mysku")

err := query.Execute(&respData)
if err != nil {
	panic(err)
}
fmt.Println(respData.Product.ID)
```

See also https://github.com/labd/terraform-provider-commercetools/pull/109/files