### PR TITLE
Add commercetools.NewClient() to create a commercetools Client

### DIFF
--- a/commercetools/client.go
+++ b/commercetools/client.go
@@ -37,6 +37,7 @@ type ClientConfig struct {
 	ProjectKey     string
 	Endpoints      *ClientEndpoints
 	Credentials    *ClientCredentials
+	HTTPClient     *http.Client
 	LibraryName    string
 	LibraryVersion string
 	ContactURL     string
@@ -152,12 +153,22 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 		TokenURL:     cfg.Endpoints.Auth,
 	}
 
+	// If a custom httpClient is passed use that
+	var httpClient *http.Client
+	if cfg.HTTPClient != nil {
+		httpClient = auth.Client(
+			context.WithValue(oauth2.NoContext, oauth2.HTTPClient, cfg.HTTPClient))
+	} else {
+		httpClient = auth.Client(context.TODO())
+	}
+
 	client := &Client{
 		projectKey: getConfigValue(cfg.ProjectKey, "CTP_PROJECT_KEY"),
 		endpoints:  *cfg.Endpoints,
-		httpClient: auth.Client(context.TODO()),
+		httpClient: httpClient,
 		userAgent:  GetUserAgent(cfg),
 	}
+
 	if os.Getenv("CTP_DEBUG") != "" {
 		client.logLevel = 1
 	}

--- a/commercetools/client_useragent.go
+++ b/commercetools/client_useragent.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetUserAgent determines the user agent for all HTTP requests.
-func GetUserAgent(cfg *Config) string {
+func GetUserAgent(cfg *ClientConfig) string {
 	baseInfo := fmt.Sprintf("commercetools-go-sdk/%s", Version)
 	systemInfo := fmt.Sprintf("Go/%s (%s; %s)", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 

--- a/commercetools/client_useragent_test.go
+++ b/commercetools/client_useragent_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestUserAgents(t *testing.T) {
 	testCases := []struct {
-		cfg               *commercetools.Config
+		cfg               *commercetools.ClientConfig
 		expectedUserAgent string
 	}{
 		{
-			cfg: &commercetools.Config{
+			cfg: &commercetools.ClientConfig{
 				LibraryName:    "terraform-provider-commercetools",
 				LibraryVersion: "0.1",
 				ContactURL:     "https://example.com",
@@ -26,7 +26,7 @@ func TestUserAgents(t *testing.T) {
 				commercetools.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		},
 		{
-			cfg: &commercetools.Config{
+			cfg: &commercetools.ClientConfig{
 				ContactURL:   "https://example.com",
 				ContactEmail: "test@example.org",
 			},
@@ -35,7 +35,7 @@ func TestUserAgents(t *testing.T) {
 				commercetools.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		},
 		{
-			cfg: &commercetools.Config{
+			cfg: &commercetools.ClientConfig{
 				LibraryName:    "terraform-provider-commercetools",
 				LibraryVersion: "0.1",
 				ContactEmail:   "test@example.org",
@@ -45,7 +45,7 @@ func TestUserAgents(t *testing.T) {
 				commercetools.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		},
 		{
-			cfg: &commercetools.Config{
+			cfg: &commercetools.ClientConfig{
 				LibraryName:  "terraform-provider-commercetools",
 				ContactURL:   "https://example.com",
 				ContactEmail: "test@example.org",


### PR DESCRIPTION
This is a new alternative for commercetools.New() with a more user
friendly API. It also adds support for passing in multiple endpoints
like the merchant center API url.

Usage example (more options can be passed)

	client, err := commercetools.NewClient(&commercetools.ClientConfig{
		ProjectKey: "my-project",
		Endpoints:  commercetools.NewClientEndpoints("europe-west1", "gcp"),
		Credentials: &commercetools.ClientCredentials{
			ClientID:     "my-client-id",
			ClientSecret: "my-client-secret",
			Scopes:       []string{"my-scope"},
		},
	})

The old version was:

	oauth2Config := &clientcredentials.Config{
		ClientID:         "my-client-id",
		ClientSecret: "my-client-secret",
		Scopes:          oauthScopes,
		TokenURL:     "https://auth.europe-west1.gcp.commercetools.com/oauth/token",
	}
	httpClient := oauth2Config.Client(context.TODO())

	client := commercetools.New(&commercetools.Config{
		ProjectKey:     "my-project",
		URL:                "https://api.europe-west1.gcp.commercetools.com",
		HTTPClient:    httpClient,
	})


Open tasks
- [x] How to handle passing the context
- [x] Unit tests