### PR TITLE
Add context.Context parameter to all service calls

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [1.12, 1.13, 1.14]
+        go-version: ['1.14']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go ${{ matrix.go-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.0 (unreleased)
+==================
+ - *Backwards incompatible:* Add context parameter to all method calls
+
+
 0.1.0 (2020-07-07)
 ==================
 First versioned release. Although this library has been in development for

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	go build
+
 test:
 	go test ./...
 

--- a/commercetools/client.go
+++ b/commercetools/client.go
@@ -228,31 +228,31 @@ func getConfigValue(value string, envName string) string {
 }
 
 // Get accomodates get requests tot the CommerceTools platform.
-func (c *Client) Get(endpoint string, queryParams url.Values, output interface{}) error {
-	err := c.doRequest("GET", endpoint, queryParams, nil, output)
+func (c *Client) Get(ctx context.Context, endpoint string, queryParams url.Values, output interface{}) error {
+	err := c.doRequest(ctx, "GET", endpoint, queryParams, nil, output)
 	return err
 }
 
 // Query accomodates query requests tot the CommerceTools platform.
-func (c *Client) Query(endpoint string, queryParams url.Values, output interface{}) error {
-	err := c.doRequest("GET", endpoint, queryParams, nil, output)
+func (c *Client) Query(ctx context.Context, endpoint string, queryParams url.Values, output interface{}) error {
+	err := c.doRequest(ctx, "GET", endpoint, queryParams, nil, output)
 	return err
 }
 
 // Create accomodates post intended for creation requests tot the CommerceTools
 // platform.
-func (c *Client) Create(endpoint string, queryParams url.Values, input interface{}, output interface{}) error {
+func (c *Client) Create(ctx context.Context, endpoint string, queryParams url.Values, input interface{}, output interface{}) error {
 	data, err := serializeInput(input)
 	if err != nil {
 		return err
 	}
-	err = c.doRequest("POST", endpoint, queryParams, data, output)
+	err = c.doRequest(ctx, "POST", endpoint, queryParams, data, output)
 	return err
 }
 
 // Update accomodates post requests intended for updates tot the CommerceTools
 // platform.
-func (c *Client) Update(endpoint string, queryParams url.Values, version int, actions interface{}, output interface{}) error {
+func (c *Client) Update(ctx context.Context, endpoint string, queryParams url.Values, version int, actions interface{}, output interface{}) error {
 	data, err := serializeInput(&map[string]interface{}{
 		"version": version,
 		"actions": actions,
@@ -260,19 +260,19 @@ func (c *Client) Update(endpoint string, queryParams url.Values, version int, ac
 	if err != nil {
 		return err
 	}
-	err = c.doRequest("POST", endpoint, queryParams, data, output)
+	err = c.doRequest(ctx, "POST", endpoint, queryParams, data, output)
 	return err
 }
 
 // Delete accomodates delete requests tot the CommerceTools platform.
-func (c *Client) Delete(endpoint string, queryParams url.Values, output interface{}) error {
-	err := c.doRequest("DELETE", endpoint, queryParams, nil, output)
+func (c *Client) Delete(ctx context.Context, endpoint string, queryParams url.Values, output interface{}) error {
+	err := c.doRequest(ctx, "DELETE", endpoint, queryParams, nil, output)
 	return err
 }
 
-func (c *Client) doRequest(method string, endpoint string, params url.Values, data io.Reader, output interface{}) error {
+func (c *Client) doRequest(ctx context.Context, method string, endpoint string, params url.Values, data io.Reader, output interface{}) error {
 	url := c.endpoints.API + "/" + c.projectKey + "/" + endpoint
-	req, err := http.NewRequest(method, url, data)
+	req, err := http.NewRequestWithContext(ctx, method, url, data)
 	if err != nil {
 		return errors.Wrap(err, "Creating new request")
 	}

--- a/commercetools/client_test.go
+++ b/commercetools/client_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +30,7 @@ func TestClientGetBadRequestJson(t *testing.T) {
 
 	output := OutputData{}
 
-	err := client.Get("/", nil, &output)
+	err := client.Get(context.TODO(), "/", nil, &output)
 	assert.Equal(t, "invalid character ',' looking for beginning of value", err.Error())
 }
 
@@ -41,7 +42,7 @@ func TestClientNotFound(t *testing.T) {
 
 	output := OutputData{}
 
-	err := client.Get("/", nil, &output)
+	err := client.Get(context.TODO(), "/", nil, &output)
 	assert.Equal(t, "Not Found (404): ResourceNotFound", err.Error())
 
 	ctErr, ok := err.(commercetools.ErrorResponse)
@@ -92,7 +93,7 @@ func TestOAuth2TokenError(t *testing.T) {
 		Name:  "test",
 		Scope: "manage_orders:my-ct-project-key manage_payments:my-ct-project-key",
 	}
-	_, err = client.APIClientCreate(draft)
+	_, err = client.APIClientCreate(context.TODO(), draft)
 
 	// Validate that we have received a valid error response
 	assert.Equal(t, "Please provide valid client credentials using HTTP Basic Authentication.", err.Error())
@@ -148,7 +149,7 @@ func TestClientRequest(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	query, err := client.ProductQuery(&commercetools.QueryInput{})
+	query, err := client.ProductQuery(context.TODO(), &commercetools.QueryInput{})
 	assert.NoError(t, err)
 	assert.Equal(t, query.Total, 0)
 }
@@ -201,7 +202,7 @@ func TestClientRequestCustomHTTPClient(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	query, err := client.ProductQuery(&commercetools.QueryInput{})
+	query, err := client.ProductQuery(context.TODO(), &commercetools.QueryInput{})
 	assert.NoError(t, err)
 	assert.Equal(t, query.Total, 0)
 }
@@ -226,7 +227,7 @@ func TestAuthError(t *testing.T) {
 
 	output := OutputData{}
 
-	err := client.Get("/", nil, &output)
+	err := client.Get(context.TODO(), "/", nil, &output)
 
 	assert.Equal(t, "Insufficient scope", err.Error())
 
@@ -257,7 +258,7 @@ func TestInvalidJsonError(t *testing.T) {
 
 	output := OutputData{}
 
-	err := client.Get("/", nil, &output)
+	err := client.Get(context.TODO(), "/", nil, &output)
 
 	assert.Equal(t, "Request body does not contain valid JSON.", err.Error())
 
@@ -335,7 +336,7 @@ func TestQueryInput(t *testing.T) {
 			client, server := testutil.MockClient(t, "{}", &output, nil)
 			defer server.Close()
 
-			_, err := client.TaxCategoryQuery(tC.input)
+			_, err := client.TaxCategoryQuery(context.TODO(), tC.input)
 
 			assert.Nil(t, err)
 			assert.Equal(t, tC.query, output.URL.Query())

--- a/commercetools/service_api_client.go
+++ b/commercetools/service_api_client.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strings"
 )
@@ -11,8 +12,8 @@ import (
 const APIClientURLPath = "api-clients"
 
 // APIClientCreate creates a new instance of type APIClient
-func (client *Client) APIClientCreate(draft *APIClientDraft) (result *APIClient, err error) {
-	err = client.Create(APIClientURLPath, nil, draft, &result)
+func (client *Client) APIClientCreate(ctx context.Context, draft *APIClientDraft) (result *APIClient, err error) {
+	err = client.Create(ctx, APIClientURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -20,8 +21,8 @@ func (client *Client) APIClientCreate(draft *APIClientDraft) (result *APIClient,
 }
 
 // APIClientQuery allows querying for type APIClient
-func (client *Client) APIClientQuery(input *QueryInput) (result *APIClientPagedQueryResponse, err error) {
-	err = client.Query(APIClientURLPath, input.toParams(), &result)
+func (client *Client) APIClientQuery(ctx context.Context, input *QueryInput) (result *APIClientPagedQueryResponse, err error) {
+	err = client.Query(ctx, APIClientURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -29,10 +30,10 @@ func (client *Client) APIClientQuery(input *QueryInput) (result *APIClientPagedQ
 }
 
 // APIClientDeleteWithID Delete ApiClient by ID
-func (client *Client) APIClientDeleteWithID(ID string) (result *APIClient, err error) {
+func (client *Client) APIClientDeleteWithID(ctx context.Context, ID string) (result *APIClient, err error) {
 	params := url.Values{}
 
-	err = client.Delete(strings.Replace("api-clients/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("api-clients/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +41,8 @@ func (client *Client) APIClientDeleteWithID(ID string) (result *APIClient, err e
 }
 
 // APIClientGetWithID Get ApiClient by ID
-func (client *Client) APIClientGetWithID(ID string) (result *APIClient, err error) {
-	err = client.Get(strings.Replace("api-clients/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) APIClientGetWithID(ctx context.Context, ID string) (result *APIClient, err error) {
+	err = client.Get(ctx, strings.Replace("api-clients/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_api_client_test.go
+++ b/commercetools/service_api_client_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -25,7 +26,7 @@ func TestAPIClientCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.APIClientCreate(input)
+	_, err := client.APIClientCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -41,7 +42,7 @@ func TestAPIClientDelete(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.APIClientDeleteWithID("1234")
+	_, err := client.APIClientDeleteWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 
 	assert.Equal(t, "/unittest/api-clients/1234", output.URL.Path)
@@ -62,7 +63,7 @@ func TestAPIClientGetByID(t *testing.T) {
 		Secret:     "secret-passphrase",
 	}
 
-	result, err := client.APIClientGetWithID("1234")
+	result, err := client.APIClientGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -75,7 +76,7 @@ func TestAPIClientQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.APIClientQuery(&queryInput)
+	_, err := client.APIClientQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_cart.go
+++ b/commercetools/service_cart.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const CartURLPath = "carts"
 
 // CartCreate creates a new instance of type Cart
-func (client *Client) CartCreate(draft *CartDraft) (result *Cart, err error) {
-	err = client.Create(CartURLPath, nil, draft, &result)
+func (client *Client) CartCreate(ctx context.Context, draft *CartDraft) (result *Cart, err error) {
+	err = client.Create(ctx, CartURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) CartCreate(draft *CartDraft) (result *Cart, err error) {
 }
 
 // CartQuery allows querying for type Cart
-func (client *Client) CartQuery(input *QueryInput) (result *CartPagedQueryResponse, err error) {
-	err = client.Query(CartURLPath, input.toParams(), &result)
+func (client *Client) CartQuery(ctx context.Context, input *QueryInput) (result *CartPagedQueryResponse, err error) {
+	err = client.Query(ctx, CartURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) CartQuery(input *QueryInput) (result *CartPagedQueryRespon
 }
 
 // CartDeleteWithID for type Cart
-func (client *Client) CartDeleteWithID(ID string, version int, dataErasure bool) (result *Cart, err error) {
+func (client *Client) CartDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Cart, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("carts/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("carts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +46,8 @@ func (client *Client) CartDeleteWithID(ID string, version int, dataErasure bool)
 CartGetWithID The cart may not contain up-to-date prices, discounts etc.
 If you want to ensure they’re up-to-date, send an Update request with the Recalculate update action instead.
 */
-func (client *Client) CartGetWithID(ID string) (result *Cart, err error) {
-	err = client.Get(strings.Replace("carts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CartGetWithID(ctx context.Context, ID string) (result *Cart, err error) {
+	err = client.Get(ctx, strings.Replace("carts/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +62,8 @@ type CartUpdateWithIDInput struct {
 }
 
 // CartUpdateWithID for type Cart
-func (client *Client) CartUpdateWithID(input *CartUpdateWithIDInput) (result *Cart, err error) {
-	err = client.Update(strings.Replace("carts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartUpdateWithID(ctx context.Context, input *CartUpdateWithIDInput) (result *Cart, err error) {
+	err = client.Update(ctx, strings.Replace("carts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_cart_discount.go
+++ b/commercetools/service_cart_discount.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const CartDiscountURLPath = "cart-discounts"
 
 // CartDiscountCreate creates a new instance of type CartDiscount
-func (client *Client) CartDiscountCreate(draft *CartDiscountDraft) (result *CartDiscount, err error) {
-	err = client.Create(CartDiscountURLPath, nil, draft, &result)
+func (client *Client) CartDiscountCreate(ctx context.Context, draft *CartDiscountDraft) (result *CartDiscount, err error) {
+	err = client.Create(ctx, CartDiscountURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) CartDiscountCreate(draft *CartDiscountDraft) (result *Cart
 }
 
 // CartDiscountQuery allows querying for type CartDiscount
-func (client *Client) CartDiscountQuery(input *QueryInput) (result *CartDiscountPagedQueryResponse, err error) {
-	err = client.Query(CartDiscountURLPath, input.toParams(), &result)
+func (client *Client) CartDiscountQuery(ctx context.Context, input *QueryInput) (result *CartDiscountPagedQueryResponse, err error) {
+	err = client.Query(ctx, CartDiscountURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) CartDiscountQuery(input *QueryInput) (result *CartDiscount
 }
 
 // CartDiscountDeleteWithKey for type CartDiscount
-func (client *Client) CartDiscountDeleteWithKey(key string, version int) (result *CartDiscount, err error) {
+func (client *Client) CartDiscountDeleteWithKey(ctx context.Context, key string, version int) (result *CartDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("cart-discounts/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("cart-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) CartDiscountDeleteWithKey(key string, version int) (result
 }
 
 // CartDiscountGetWithKey for type CartDiscount
-func (client *Client) CartDiscountGetWithKey(key string) (result *CartDiscount, err error) {
-	err = client.Get(strings.Replace("cart-discounts/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CartDiscountGetWithKey(ctx context.Context, key string) (result *CartDiscount, err error) {
+	err = client.Get(ctx, strings.Replace("cart-discounts/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type CartDiscountUpdateWithKeyInput struct {
 }
 
 // CartDiscountUpdateWithKey for type CartDiscount
-func (client *Client) CartDiscountUpdateWithKey(input *CartDiscountUpdateWithKeyInput) (result *CartDiscount, err error) {
-	err = client.Update(strings.Replace("cart-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartDiscountUpdateWithKey(ctx context.Context, input *CartDiscountUpdateWithKeyInput) (result *CartDiscount, err error) {
+	err = client.Update(ctx, strings.Replace("cart-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) CartDiscountUpdateWithKey(input *CartDiscountUpdateWithKey
 }
 
 // CartDiscountDeleteWithID for type CartDiscount
-func (client *Client) CartDiscountDeleteWithID(ID string, version int) (result *CartDiscount, err error) {
+func (client *Client) CartDiscountDeleteWithID(ctx context.Context, ID string, version int) (result *CartDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) CartDiscountDeleteWithID(ID string, version int) (result *
 }
 
 // CartDiscountGetWithID for type CartDiscount
-func (client *Client) CartDiscountGetWithID(ID string) (result *CartDiscount, err error) {
-	err = client.Get(strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CartDiscountGetWithID(ctx context.Context, ID string) (result *CartDiscount, err error) {
+	err = client.Get(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type CartDiscountUpdateWithIDInput struct {
 }
 
 // CartDiscountUpdateWithID for type CartDiscount
-func (client *Client) CartDiscountUpdateWithID(input *CartDiscountUpdateWithIDInput) (result *CartDiscount, err error) {
-	err = client.Update(strings.Replace("cart-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartDiscountUpdateWithID(ctx context.Context, input *CartDiscountUpdateWithIDInput) (result *CartDiscount, err error) {
+	err = client.Update(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_cart_test.go
+++ b/commercetools/service_cart_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -24,7 +25,7 @@ func TestCartCreate(t *testing.T) {
 		},
 	}
 
-	cart, err := client.CartCreate(input)
+	cart, err := client.CartCreate(context.TODO(), input)
 	fmt.Printf("%#v", cart)
 	assert.Nil(t, err)
 
@@ -67,7 +68,7 @@ func TestCartUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, "{}", &output, nil)
 			defer server.Close()
 
-			_, err := client.CartUpdateWithID(tC.input)
+			_, err := client.CartUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/carts/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -80,7 +81,7 @@ func TestCartDelete(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.CartDeleteWithID("debd77c9-ef14-4595-8614-5d123429f9e1", 2, true)
+	_, err := client.CartDeleteWithID(context.TODO(), "debd77c9-ef14-4595-8614-5d123429f9e1", 2, true)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -94,7 +95,7 @@ func TestCartGetByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("cart.json"), nil, nil)
 	defer server.Close()
 
-	cart, err := client.CartGetWithID("debd77c9-ef14-4595-8614-5d123429f9e1")
+	cart, err := client.CartGetWithID(context.TODO(), "debd77c9-ef14-4595-8614-5d123429f9e1")
 
 	assert.Nil(t, err)
 	assert.Equal(t, "debd77c9-ef14-4595-8614-5d123429f9e1", cart.ID)
@@ -108,7 +109,7 @@ func TestCartQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.CartQuery(&queryInput)
+	_, err := client.CartQuery(context.TODO(), &queryInput)
 
 	assert.Nil(t, err)
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_category.go
+++ b/commercetools/service_category.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const CategoryURLPath = "categories"
 
 // CategoryCreate creates a new instance of type Category
-func (client *Client) CategoryCreate(draft *CategoryDraft) (result *Category, err error) {
-	err = client.Create(CategoryURLPath, nil, draft, &result)
+func (client *Client) CategoryCreate(ctx context.Context, draft *CategoryDraft) (result *Category, err error) {
+	err = client.Create(ctx, CategoryURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) CategoryCreate(draft *CategoryDraft) (result *Category, er
 }
 
 // CategoryQuery allows querying for type Category
-func (client *Client) CategoryQuery(input *QueryInput) (result *CategoryPagedQueryResponse, err error) {
-	err = client.Query(CategoryURLPath, input.toParams(), &result)
+func (client *Client) CategoryQuery(ctx context.Context, input *QueryInput) (result *CategoryPagedQueryResponse, err error) {
+	err = client.Query(ctx, CategoryURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) CategoryQuery(input *QueryInput) (result *CategoryPagedQue
 }
 
 // CategoryDeleteWithKey for type Category
-func (client *Client) CategoryDeleteWithKey(key string, version int) (result *Category, err error) {
+func (client *Client) CategoryDeleteWithKey(ctx context.Context, key string, version int) (result *Category, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("categories/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) CategoryDeleteWithKey(key string, version int) (result *Ca
 }
 
 // CategoryGetWithKey for type Category
-func (client *Client) CategoryGetWithKey(key string) (result *Category, err error) {
-	err = client.Get(strings.Replace("categories/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CategoryGetWithKey(ctx context.Context, key string) (result *Category, err error) {
+	err = client.Get(ctx, strings.Replace("categories/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type CategoryUpdateWithKeyInput struct {
 }
 
 // CategoryUpdateWithKey for type Category
-func (client *Client) CategoryUpdateWithKey(input *CategoryUpdateWithKeyInput) (result *Category, err error) {
-	err = client.Update(strings.Replace("categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CategoryUpdateWithKey(ctx context.Context, input *CategoryUpdateWithKeyInput) (result *Category, err error) {
+	err = client.Update(ctx, strings.Replace("categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) CategoryUpdateWithKey(input *CategoryUpdateWithKeyInput) (
 }
 
 // CategoryDeleteWithID for type Category
-func (client *Client) CategoryDeleteWithID(ID string, version int) (result *Category, err error) {
+func (client *Client) CategoryDeleteWithID(ctx context.Context, ID string, version int) (result *Category, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("categories/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) CategoryDeleteWithID(ID string, version int) (result *Cate
 }
 
 // CategoryGetWithID for type Category
-func (client *Client) CategoryGetWithID(ID string) (result *Category, err error) {
-	err = client.Get(strings.Replace("categories/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CategoryGetWithID(ctx context.Context, ID string) (result *Category, err error) {
+	err = client.Get(ctx, strings.Replace("categories/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type CategoryUpdateWithIDInput struct {
 }
 
 // CategoryUpdateWithID for type Category
-func (client *Client) CategoryUpdateWithID(input *CategoryUpdateWithIDInput) (result *Category, err error) {
-	err = client.Update(strings.Replace("categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CategoryUpdateWithID(ctx context.Context, input *CategoryUpdateWithIDInput) (result *Category, err error) {
+	err = client.Update(ctx, strings.Replace("categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_channel.go
+++ b/commercetools/service_channel.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ChannelURLPath = "channels"
 
 // ChannelCreate creates a new instance of type Channel
-func (client *Client) ChannelCreate(draft *ChannelDraft) (result *Channel, err error) {
-	err = client.Create(ChannelURLPath, nil, draft, &result)
+func (client *Client) ChannelCreate(ctx context.Context, draft *ChannelDraft) (result *Channel, err error) {
+	err = client.Create(ctx, ChannelURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ChannelCreate(draft *ChannelDraft) (result *Channel, err e
 }
 
 // ChannelQuery allows querying for type Channel
-func (client *Client) ChannelQuery(input *QueryInput) (result *ChannelPagedQueryResponse, err error) {
-	err = client.Query(ChannelURLPath, input.toParams(), &result)
+func (client *Client) ChannelQuery(ctx context.Context, input *QueryInput) (result *ChannelPagedQueryResponse, err error) {
+	err = client.Query(ctx, ChannelURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ChannelQuery(input *QueryInput) (result *ChannelPagedQuery
 }
 
 // ChannelDeleteWithID for type Channel
-func (client *Client) ChannelDeleteWithID(ID string, version int) (result *Channel, err error) {
+func (client *Client) ChannelDeleteWithID(ctx context.Context, ID string, version int) (result *Channel, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("channels/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("channels/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ChannelDeleteWithID(ID string, version int) (result *Chann
 }
 
 // ChannelGetWithID for type Channel
-func (client *Client) ChannelGetWithID(ID string) (result *Channel, err error) {
-	err = client.Get(strings.Replace("channels/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ChannelGetWithID(ctx context.Context, ID string) (result *Channel, err error) {
+	err = client.Get(ctx, strings.Replace("channels/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ChannelUpdateWithIDInput struct {
 }
 
 // ChannelUpdateWithID for type Channel
-func (client *Client) ChannelUpdateWithID(input *ChannelUpdateWithIDInput) (result *Channel, err error) {
-	err = client.Update(strings.Replace("channels/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ChannelUpdateWithID(ctx context.Context, input *ChannelUpdateWithIDInput) (result *Channel, err error) {
+	err = client.Update(ctx, strings.Replace("channels/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_channel_test.go
+++ b/commercetools/service_channel_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -31,7 +32,7 @@ func TestChannelCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.ChannelCreate(input)
+	_, err := client.ChannelCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -315,7 +316,7 @@ func TestChannelUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, "{}", &output, nil)
 			defer server.Close()
 
-			_, err := client.ChannelUpdateWithID(tC.input)
+			_, err := client.ChannelUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/channels/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -328,7 +329,7 @@ func TestChannelDelete(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.ChannelDeleteWithID("1234", 2)
+	_, err := client.ChannelDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -352,7 +353,7 @@ func TestChannelGetByID(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.ChannelGetWithID("1234")
+	result, err := client.ChannelGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -365,7 +366,7 @@ func TestChannelQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ChannelQuery(&queryInput)
+	_, err := client.ChannelQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_customer.go
+++ b/commercetools/service_customer.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const CustomerURLPath = "customers"
 
 // CustomerCreate creates a new instance of type Customer
-func (client *Client) CustomerCreate(draft *CustomerDraft) (result *Customer, err error) {
-	err = client.Create(CustomerURLPath, nil, draft, &result)
+func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft) (result *Customer, err error) {
+	err = client.Create(ctx, CustomerURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) CustomerCreate(draft *CustomerDraft) (result *Customer, er
 }
 
 // CustomerQuery allows querying for type Customer
-func (client *Client) CustomerQuery(input *QueryInput) (result *CustomerPagedQueryResponse, err error) {
-	err = client.Query(CustomerURLPath, input.toParams(), &result)
+func (client *Client) CustomerQuery(ctx context.Context, input *QueryInput) (result *CustomerPagedQueryResponse, err error) {
+	err = client.Query(ctx, CustomerURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) CustomerQuery(input *QueryInput) (result *CustomerPagedQue
 }
 
 // CustomerDeleteWithKey for type Customer
-func (client *Client) CustomerDeleteWithKey(key string, version int, dataErasure bool) (result *Customer, err error) {
+func (client *Client) CustomerDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Customer, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("customers/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("customers/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) CustomerDeleteWithKey(key string, version int, dataErasure
 }
 
 // CustomerGetWithKey for type Customer
-func (client *Client) CustomerGetWithKey(key string) (result *Customer, err error) {
-	err = client.Get(strings.Replace("customers/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CustomerGetWithKey(ctx context.Context, key string) (result *Customer, err error) {
+	err = client.Get(ctx, strings.Replace("customers/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type CustomerUpdateWithKeyInput struct {
 }
 
 // CustomerUpdateWithKey for type Customer
-func (client *Client) CustomerUpdateWithKey(input *CustomerUpdateWithKeyInput) (result *Customer, err error) {
-	err = client.Update(strings.Replace("customers/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerUpdateWithKey(ctx context.Context, input *CustomerUpdateWithKeyInput) (result *Customer, err error) {
+	err = client.Update(ctx, strings.Replace("customers/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) CustomerUpdateWithKey(input *CustomerUpdateWithKeyInput) (
 }
 
 // CustomerDeleteWithID for type Customer
-func (client *Client) CustomerDeleteWithID(ID string, version int, dataErasure bool) (result *Customer, err error) {
+func (client *Client) CustomerDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Customer, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("customers/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("customers/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) CustomerDeleteWithID(ID string, version int, dataErasure b
 }
 
 // CustomerGetWithID for type Customer
-func (client *Client) CustomerGetWithID(ID string) (result *Customer, err error) {
-	err = client.Get(strings.Replace("customers/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CustomerGetWithID(ctx context.Context, ID string) (result *Customer, err error) {
+	err = client.Get(ctx, strings.Replace("customers/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type CustomerUpdateWithIDInput struct {
 }
 
 // CustomerUpdateWithID for type Customer
-func (client *Client) CustomerUpdateWithID(input *CustomerUpdateWithIDInput) (result *Customer, err error) {
-	err = client.Update(strings.Replace("customers/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerUpdateWithID(ctx context.Context, input *CustomerUpdateWithIDInput) (result *Customer, err error) {
+	err = client.Update(ctx, strings.Replace("customers/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_customer_group.go
+++ b/commercetools/service_customer_group.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const CustomerGroupURLPath = "customer-groups"
 
 // CustomerGroupCreate creates a new instance of type CustomerGroup
-func (client *Client) CustomerGroupCreate(draft *CustomerGroupDraft) (result *CustomerGroup, err error) {
-	err = client.Create(CustomerGroupURLPath, nil, draft, &result)
+func (client *Client) CustomerGroupCreate(ctx context.Context, draft *CustomerGroupDraft) (result *CustomerGroup, err error) {
+	err = client.Create(ctx, CustomerGroupURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) CustomerGroupCreate(draft *CustomerGroupDraft) (result *Cu
 }
 
 // CustomerGroupQuery allows querying for type CustomerGroup
-func (client *Client) CustomerGroupQuery(input *QueryInput) (result *CustomerGroupPagedQueryResponse, err error) {
-	err = client.Query(CustomerGroupURLPath, input.toParams(), &result)
+func (client *Client) CustomerGroupQuery(ctx context.Context, input *QueryInput) (result *CustomerGroupPagedQueryResponse, err error) {
+	err = client.Query(ctx, CustomerGroupURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) CustomerGroupQuery(input *QueryInput) (result *CustomerGro
 }
 
 // CustomerGroupDeleteWithKey for type CustomerGroup
-func (client *Client) CustomerGroupDeleteWithKey(key string, version int) (result *CustomerGroup, err error) {
+func (client *Client) CustomerGroupDeleteWithKey(ctx context.Context, key string, version int) (result *CustomerGroup, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("customer-groups/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("customer-groups/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) CustomerGroupDeleteWithKey(key string, version int) (resul
 }
 
 // CustomerGroupGetWithKey Gets a customer group by Key.
-func (client *Client) CustomerGroupGetWithKey(key string) (result *CustomerGroup, err error) {
-	err = client.Get(strings.Replace("customer-groups/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CustomerGroupGetWithKey(ctx context.Context, key string) (result *CustomerGroup, err error) {
+	err = client.Get(ctx, strings.Replace("customer-groups/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type CustomerGroupUpdateWithKeyInput struct {
 }
 
 // CustomerGroupUpdateWithKey Updates a customer group by Key.
-func (client *Client) CustomerGroupUpdateWithKey(input *CustomerGroupUpdateWithKeyInput) (result *CustomerGroup, err error) {
-	err = client.Update(strings.Replace("customer-groups/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerGroupUpdateWithKey(ctx context.Context, input *CustomerGroupUpdateWithKeyInput) (result *CustomerGroup, err error) {
+	err = client.Update(ctx, strings.Replace("customer-groups/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) CustomerGroupUpdateWithKey(input *CustomerGroupUpdateWithK
 }
 
 // CustomerGroupDeleteWithID for type CustomerGroup
-func (client *Client) CustomerGroupDeleteWithID(ID string, version int) (result *CustomerGroup, err error) {
+func (client *Client) CustomerGroupDeleteWithID(ctx context.Context, ID string, version int) (result *CustomerGroup, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) CustomerGroupDeleteWithID(ID string, version int) (result 
 }
 
 // CustomerGroupGetWithID for type CustomerGroup
-func (client *Client) CustomerGroupGetWithID(ID string) (result *CustomerGroup, err error) {
-	err = client.Get(strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CustomerGroupGetWithID(ctx context.Context, ID string) (result *CustomerGroup, err error) {
+	err = client.Get(ctx, strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type CustomerGroupUpdateWithIDInput struct {
 }
 
 // CustomerGroupUpdateWithID for type CustomerGroup
-func (client *Client) CustomerGroupUpdateWithID(input *CustomerGroupUpdateWithIDInput) (result *CustomerGroup, err error) {
-	err = client.Update(strings.Replace("customer-groups/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerGroupUpdateWithID(ctx context.Context, input *CustomerGroupUpdateWithIDInput) (result *CustomerGroup, err error) {
+	err = client.Update(ctx, strings.Replace("customer-groups/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_discount_code.go
+++ b/commercetools/service_discount_code.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const DiscountCodeURLPath = "discount-codes"
 
 // DiscountCodeCreate creates a new instance of type DiscountCode
-func (client *Client) DiscountCodeCreate(draft *DiscountCodeDraft) (result *DiscountCode, err error) {
-	err = client.Create(DiscountCodeURLPath, nil, draft, &result)
+func (client *Client) DiscountCodeCreate(ctx context.Context, draft *DiscountCodeDraft) (result *DiscountCode, err error) {
+	err = client.Create(ctx, DiscountCodeURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) DiscountCodeCreate(draft *DiscountCodeDraft) (result *Disc
 }
 
 // DiscountCodeQuery allows querying for type DiscountCode
-func (client *Client) DiscountCodeQuery(input *QueryInput) (result *DiscountCodePagedQueryResponse, err error) {
-	err = client.Query(DiscountCodeURLPath, input.toParams(), &result)
+func (client *Client) DiscountCodeQuery(ctx context.Context, input *QueryInput) (result *DiscountCodePagedQueryResponse, err error) {
+	err = client.Query(ctx, DiscountCodeURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) DiscountCodeQuery(input *QueryInput) (result *DiscountCode
 }
 
 // DiscountCodeDeleteWithID for type DiscountCode
-func (client *Client) DiscountCodeDeleteWithID(ID string, version int, dataErasure bool) (result *DiscountCode, err error) {
+func (client *Client) DiscountCodeDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *DiscountCode, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) DiscountCodeDeleteWithID(ID string, version int, dataErasu
 }
 
 // DiscountCodeGetWithID for type DiscountCode
-func (client *Client) DiscountCodeGetWithID(ID string) (result *DiscountCode, err error) {
-	err = client.Get(strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) DiscountCodeGetWithID(ctx context.Context, ID string) (result *DiscountCode, err error) {
+	err = client.Get(ctx, strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type DiscountCodeUpdateWithIDInput struct {
 }
 
 // DiscountCodeUpdateWithID for type DiscountCode
-func (client *Client) DiscountCodeUpdateWithID(input *DiscountCodeUpdateWithIDInput) (result *DiscountCode, err error) {
-	err = client.Update(strings.Replace("discount-codes/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) DiscountCodeUpdateWithID(ctx context.Context, input *DiscountCodeUpdateWithIDInput) (result *DiscountCode, err error) {
+	err = client.Update(ctx, strings.Replace("discount-codes/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_extension.go
+++ b/commercetools/service_extension.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ExtensionURLPath = "extensions"
 
 // ExtensionCreate creates a new instance of type Extension
-func (client *Client) ExtensionCreate(draft *ExtensionDraft) (result *Extension, err error) {
-	err = client.Create(ExtensionURLPath, nil, draft, &result)
+func (client *Client) ExtensionCreate(ctx context.Context, draft *ExtensionDraft) (result *Extension, err error) {
+	err = client.Create(ctx, ExtensionURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ExtensionCreate(draft *ExtensionDraft) (result *Extension,
 }
 
 // ExtensionQuery allows querying for type Extension
-func (client *Client) ExtensionQuery(input *QueryInput) (result *ExtensionPagedQueryResponse, err error) {
-	err = client.Query(ExtensionURLPath, input.toParams(), &result)
+func (client *Client) ExtensionQuery(ctx context.Context, input *QueryInput) (result *ExtensionPagedQueryResponse, err error) {
+	err = client.Query(ctx, ExtensionURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ExtensionQuery(input *QueryInput) (result *ExtensionPagedQ
 }
 
 // ExtensionDeleteWithKey for type Extension
-func (client *Client) ExtensionDeleteWithKey(key string, version int) (result *Extension, err error) {
+func (client *Client) ExtensionDeleteWithKey(ctx context.Context, key string, version int) (result *Extension, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("extensions/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("extensions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ExtensionDeleteWithKey(key string, version int) (result *E
 }
 
 // ExtensionGetWithKey Retrieves the representation of an extension by its key.
-func (client *Client) ExtensionGetWithKey(key string) (result *Extension, err error) {
-	err = client.Get(strings.Replace("extensions/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ExtensionGetWithKey(ctx context.Context, key string) (result *Extension, err error) {
+	err = client.Get(ctx, strings.Replace("extensions/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ExtensionUpdateWithKeyInput struct {
 }
 
 // ExtensionUpdateWithKey for type Extension
-func (client *Client) ExtensionUpdateWithKey(input *ExtensionUpdateWithKeyInput) (result *Extension, err error) {
-	err = client.Update(strings.Replace("extensions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ExtensionUpdateWithKey(ctx context.Context, input *ExtensionUpdateWithKeyInput) (result *Extension, err error) {
+	err = client.Update(ctx, strings.Replace("extensions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ExtensionUpdateWithKey(input *ExtensionUpdateWithKeyInput)
 }
 
 // ExtensionDeleteWithID for type Extension
-func (client *Client) ExtensionDeleteWithID(ID string, version int) (result *Extension, err error) {
+func (client *Client) ExtensionDeleteWithID(ctx context.Context, ID string, version int) (result *Extension, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("extensions/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("extensions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ExtensionDeleteWithID(ID string, version int) (result *Ext
 }
 
 // ExtensionGetWithID Retrieves the representation of an extension by its id.
-func (client *Client) ExtensionGetWithID(ID string) (result *Extension, err error) {
-	err = client.Get(strings.Replace("extensions/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ExtensionGetWithID(ctx context.Context, ID string) (result *Extension, err error) {
+	err = client.Get(ctx, strings.Replace("extensions/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ExtensionUpdateWithIDInput struct {
 }
 
 // ExtensionUpdateWithID for type Extension
-func (client *Client) ExtensionUpdateWithID(input *ExtensionUpdateWithIDInput) (result *Extension, err error) {
-	err = client.Update(strings.Replace("extensions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ExtensionUpdateWithID(ctx context.Context, input *ExtensionUpdateWithIDInput) (result *Extension, err error) {
+	err = client.Update(ctx, strings.Replace("extensions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_extension_test.go
+++ b/commercetools/service_extension_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -29,7 +30,7 @@ func TestExtensionCreate(t *testing.T) {
 		},
 	}
 
-	_, err := client.ExtensionCreate(draft)
+	_, err := client.ExtensionCreate(context.TODO(), draft)
 	assert.Nil(t, err)
 }
 
@@ -54,7 +55,7 @@ func TestExtensionUpdate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.ExtensionUpdateWithID(input)
+	_, err := client.ExtensionUpdateWithID(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -78,7 +79,7 @@ func TestExtensionDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("extension.azure.json"), nil, nil)
 	defer server.Close()
 
-	_, err := client.ExtensionDeleteWithID("1234", 2)
+	_, err := client.ExtensionDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 }
 
@@ -86,7 +87,7 @@ func TestExtensionDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("extension.azure.json"), nil, nil)
 	defer server.Close()
 
-	_, err := client.ExtensionDeleteWithKey("1234", 2)
+	_, err := client.ExtensionDeleteWithKey(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 }
 
@@ -98,7 +99,7 @@ func TestExtensionQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ExtensionQuery(&queryInput)
+	_, err := client.ExtensionQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_inventory.go
+++ b/commercetools/service_inventory.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const InventoryEntryURLPath = "inventory"
 
 // InventoryEntryCreate creates a new instance of type InventoryEntry
-func (client *Client) InventoryEntryCreate(draft *InventoryEntryDraft) (result *InventoryEntry, err error) {
-	err = client.Create(InventoryEntryURLPath, nil, draft, &result)
+func (client *Client) InventoryEntryCreate(ctx context.Context, draft *InventoryEntryDraft) (result *InventoryEntry, err error) {
+	err = client.Create(ctx, InventoryEntryURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) InventoryEntryCreate(draft *InventoryEntryDraft) (result *
 }
 
 // InventoryEntryQuery allows querying for type InventoryEntry
-func (client *Client) InventoryEntryQuery(input *QueryInput) (result *InventoryPagedQueryResponse, err error) {
-	err = client.Query(InventoryEntryURLPath, input.toParams(), &result)
+func (client *Client) InventoryEntryQuery(ctx context.Context, input *QueryInput) (result *InventoryPagedQueryResponse, err error) {
+	err = client.Query(ctx, InventoryEntryURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) InventoryEntryQuery(input *QueryInput) (result *InventoryP
 }
 
 // InventoryEntryDeleteWithID for type InventoryEntry
-func (client *Client) InventoryEntryDeleteWithID(ID string, version int) (result *InventoryEntry, err error) {
+func (client *Client) InventoryEntryDeleteWithID(ctx context.Context, ID string, version int) (result *InventoryEntry, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("inventory/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("inventory/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) InventoryEntryDeleteWithID(ID string, version int) (result
 }
 
 // InventoryEntryGetWithID for type InventoryEntry
-func (client *Client) InventoryEntryGetWithID(ID string) (result *InventoryEntry, err error) {
-	err = client.Get(strings.Replace("inventory/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) InventoryEntryGetWithID(ctx context.Context, ID string) (result *InventoryEntry, err error) {
+	err = client.Get(ctx, strings.Replace("inventory/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type InventoryEntryUpdateWithIDInput struct {
 }
 
 // InventoryEntryUpdateWithID for type InventoryEntry
-func (client *Client) InventoryEntryUpdateWithID(input *InventoryEntryUpdateWithIDInput) (result *InventoryEntry, err error) {
-	err = client.Update(strings.Replace("inventory/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) InventoryEntryUpdateWithID(ctx context.Context, input *InventoryEntryUpdateWithIDInput) (result *InventoryEntry, err error) {
+	err = client.Update(ctx, strings.Replace("inventory/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_message.go
+++ b/commercetools/service_message.go
@@ -2,14 +2,17 @@
 
 package commercetools
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // AbstractMessageURLPath is the commercetools API path.
 const AbstractMessageURLPath = "messages"
 
 // AbstractMessageQuery allows querying for type Message
-func (client *Client) AbstractMessageQuery(input *QueryInput) (result *MessagePagedQueryResponse, err error) {
-	err = client.Query(AbstractMessageURLPath, input.toParams(), &result)
+func (client *Client) AbstractMessageQuery(ctx context.Context, input *QueryInput) (result *MessagePagedQueryResponse, err error) {
+	err = client.Query(ctx, AbstractMessageURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -17,8 +20,8 @@ func (client *Client) AbstractMessageQuery(input *QueryInput) (result *MessagePa
 }
 
 // AbstractMessageGetWithID for type Message
-func (client *Client) AbstractMessageGetWithID(ID string) (result *Message, err error) {
-	err = client.Get(strings.Replace("messages/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) AbstractMessageGetWithID(ctx context.Context, ID string) (result *Message, err error) {
+	err = client.Get(ctx, strings.Replace("messages/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_order.go
+++ b/commercetools/service_order.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const OrderURLPath = "orders"
 
 // OrderCreate creates a new instance of type Order
-func (client *Client) OrderCreate(draft *OrderFromCartDraft) (result *Order, err error) {
-	err = client.Create(OrderURLPath, nil, draft, &result)
+func (client *Client) OrderCreate(ctx context.Context, draft *OrderFromCartDraft) (result *Order, err error) {
+	err = client.Create(ctx, OrderURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) OrderCreate(draft *OrderFromCartDraft) (result *Order, err
 }
 
 // OrderQuery allows querying for type Order
-func (client *Client) OrderQuery(input *QueryInput) (result *OrderPagedQueryResponse, err error) {
-	err = client.Query(OrderURLPath, input.toParams(), &result)
+func (client *Client) OrderQuery(ctx context.Context, input *QueryInput) (result *OrderPagedQueryResponse, err error) {
+	err = client.Query(ctx, OrderURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) OrderQuery(input *QueryInput) (result *OrderPagedQueryResp
 }
 
 // OrderDeleteWithID for type Order
-func (client *Client) OrderDeleteWithID(ID string, version int, dataErasure bool) (result *Order, err error) {
+func (client *Client) OrderDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Order, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("orders/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("orders/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) OrderDeleteWithID(ID string, version int, dataErasure bool
 }
 
 // OrderGetWithID for type Order
-func (client *Client) OrderGetWithID(ID string) (result *Order, err error) {
-	err = client.Get(strings.Replace("orders/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) OrderGetWithID(ctx context.Context, ID string) (result *Order, err error) {
+	err = client.Get(ctx, strings.Replace("orders/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type OrderUpdateWithIDInput struct {
 }
 
 // OrderUpdateWithID for type Order
-func (client *Client) OrderUpdateWithID(input *OrderUpdateWithIDInput) (result *Order, err error) {
-	err = client.Update(strings.Replace("orders/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) OrderUpdateWithID(ctx context.Context, input *OrderUpdateWithIDInput) (result *Order, err error) {
+	err = client.Update(ctx, strings.Replace("orders/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_payment.go
+++ b/commercetools/service_payment.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const PaymentURLPath = "payments"
 
 // PaymentCreate creates a new instance of type Payment
-func (client *Client) PaymentCreate(draft *PaymentDraft) (result *Payment, err error) {
-	err = client.Create(PaymentURLPath, nil, draft, &result)
+func (client *Client) PaymentCreate(ctx context.Context, draft *PaymentDraft) (result *Payment, err error) {
+	err = client.Create(ctx, PaymentURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) PaymentCreate(draft *PaymentDraft) (result *Payment, err e
 }
 
 // PaymentQuery allows querying for type Payment
-func (client *Client) PaymentQuery(input *QueryInput) (result *PaymentPagedQueryResponse, err error) {
-	err = client.Query(PaymentURLPath, input.toParams(), &result)
+func (client *Client) PaymentQuery(ctx context.Context, input *QueryInput) (result *PaymentPagedQueryResponse, err error) {
+	err = client.Query(ctx, PaymentURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) PaymentQuery(input *QueryInput) (result *PaymentPagedQuery
 }
 
 // PaymentDeleteWithKey for type Payment
-func (client *Client) PaymentDeleteWithKey(key string, version int, dataErasure bool) (result *Payment, err error) {
+func (client *Client) PaymentDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Payment, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("payments/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("payments/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) PaymentDeleteWithKey(key string, version int, dataErasure 
 }
 
 // PaymentGetWithKey for type Payment
-func (client *Client) PaymentGetWithKey(key string) (result *Payment, err error) {
-	err = client.Get(strings.Replace("payments/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) PaymentGetWithKey(ctx context.Context, key string) (result *Payment, err error) {
+	err = client.Get(ctx, strings.Replace("payments/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type PaymentUpdateWithKeyInput struct {
 }
 
 // PaymentUpdateWithKey for type Payment
-func (client *Client) PaymentUpdateWithKey(input *PaymentUpdateWithKeyInput) (result *Payment, err error) {
-	err = client.Update(strings.Replace("payments/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) PaymentUpdateWithKey(ctx context.Context, input *PaymentUpdateWithKeyInput) (result *Payment, err error) {
+	err = client.Update(ctx, strings.Replace("payments/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) PaymentUpdateWithKey(input *PaymentUpdateWithKeyInput) (re
 }
 
 // PaymentDeleteWithID for type Payment
-func (client *Client) PaymentDeleteWithID(ID string, version int, dataErasure bool) (result *Payment, err error) {
+func (client *Client) PaymentDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Payment, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("payments/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("payments/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) PaymentDeleteWithID(ID string, version int, dataErasure bo
 }
 
 // PaymentGetWithID for type Payment
-func (client *Client) PaymentGetWithID(ID string) (result *Payment, err error) {
-	err = client.Get(strings.Replace("payments/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) PaymentGetWithID(ctx context.Context, ID string) (result *Payment, err error) {
+	err = client.Get(ctx, strings.Replace("payments/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type PaymentUpdateWithIDInput struct {
 }
 
 // PaymentUpdateWithID for type Payment
-func (client *Client) PaymentUpdateWithID(input *PaymentUpdateWithIDInput) (result *Payment, err error) {
-	err = client.Update(strings.Replace("payments/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) PaymentUpdateWithID(ctx context.Context, input *PaymentUpdateWithIDInput) (result *Payment, err error) {
+	err = client.Update(ctx, strings.Replace("payments/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product.go
+++ b/commercetools/service_product.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ProductURLPath = "products"
 
 // ProductCreate creates a new instance of type Product
-func (client *Client) ProductCreate(draft *ProductDraft) (result *Product, err error) {
-	err = client.Create(ProductURLPath, nil, draft, &result)
+func (client *Client) ProductCreate(ctx context.Context, draft *ProductDraft) (result *Product, err error) {
+	err = client.Create(ctx, ProductURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ProductCreate(draft *ProductDraft) (result *Product, err e
 }
 
 // ProductQuery allows querying for type Product
-func (client *Client) ProductQuery(input *QueryInput) (result *ProductPagedQueryResponse, err error) {
-	err = client.Query(ProductURLPath, input.toParams(), &result)
+func (client *Client) ProductQuery(ctx context.Context, input *QueryInput) (result *ProductPagedQueryResponse, err error) {
+	err = client.Query(ctx, ProductURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ProductQuery(input *QueryInput) (result *ProductPagedQuery
 }
 
 // ProductDeleteWithKey for type Product
-func (client *Client) ProductDeleteWithKey(key string, version int) (result *Product, err error) {
+func (client *Client) ProductDeleteWithKey(ctx context.Context, key string, version int) (result *Product, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("products/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("products/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ProductDeleteWithKey(key string, version int) (result *Pro
 }
 
 // ProductGetWithKey Gets the full representation of a product by Key.
-func (client *Client) ProductGetWithKey(key string) (result *Product, err error) {
-	err = client.Get(strings.Replace("products/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductGetWithKey(ctx context.Context, key string) (result *Product, err error) {
+	err = client.Get(ctx, strings.Replace("products/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ProductUpdateWithKeyInput struct {
 }
 
 // ProductUpdateWithKey for type Product
-func (client *Client) ProductUpdateWithKey(input *ProductUpdateWithKeyInput) (result *Product, err error) {
-	err = client.Update(strings.Replace("products/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductUpdateWithKey(ctx context.Context, input *ProductUpdateWithKeyInput) (result *Product, err error) {
+	err = client.Update(ctx, strings.Replace("products/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ProductUpdateWithKey(input *ProductUpdateWithKeyInput) (re
 }
 
 // ProductDeleteWithID for type Product
-func (client *Client) ProductDeleteWithID(ID string, version int) (result *Product, err error) {
+func (client *Client) ProductDeleteWithID(ctx context.Context, ID string, version int) (result *Product, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("products/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("products/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ProductDeleteWithID(ID string, version int) (result *Produ
 }
 
 // ProductGetWithID Gets the full representation of a product by ID.
-func (client *Client) ProductGetWithID(ID string) (result *Product, err error) {
-	err = client.Get(strings.Replace("products/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductGetWithID(ctx context.Context, ID string) (result *Product, err error) {
+	err = client.Get(ctx, strings.Replace("products/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ProductUpdateWithIDInput struct {
 }
 
 // ProductUpdateWithID for type Product
-func (client *Client) ProductUpdateWithID(input *ProductUpdateWithIDInput) (result *Product, err error) {
-	err = client.Update(strings.Replace("products/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductUpdateWithID(ctx context.Context, input *ProductUpdateWithIDInput) (result *Product, err error) {
+	err = client.Update(ctx, strings.Replace("products/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product_discount.go
+++ b/commercetools/service_product_discount.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ProductDiscountURLPath = "product-discounts"
 
 // ProductDiscountCreate creates a new instance of type ProductDiscount
-func (client *Client) ProductDiscountCreate(draft *ProductDiscountDraft) (result *ProductDiscount, err error) {
-	err = client.Create(ProductDiscountURLPath, nil, draft, &result)
+func (client *Client) ProductDiscountCreate(ctx context.Context, draft *ProductDiscountDraft) (result *ProductDiscount, err error) {
+	err = client.Create(ctx, ProductDiscountURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ProductDiscountCreate(draft *ProductDiscountDraft) (result
 }
 
 // ProductDiscountQuery allows querying for type ProductDiscount
-func (client *Client) ProductDiscountQuery(input *QueryInput) (result *ProductDiscountPagedQueryResponse, err error) {
-	err = client.Query(ProductDiscountURLPath, input.toParams(), &result)
+func (client *Client) ProductDiscountQuery(ctx context.Context, input *QueryInput) (result *ProductDiscountPagedQueryResponse, err error) {
+	err = client.Query(ctx, ProductDiscountURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ProductDiscountQuery(input *QueryInput) (result *ProductDi
 }
 
 // ProductDiscountDeleteWithKey for type ProductDiscount
-func (client *Client) ProductDiscountDeleteWithKey(key string, version int) (result *ProductDiscount, err error) {
+func (client *Client) ProductDiscountDeleteWithKey(ctx context.Context, key string, version int) (result *ProductDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("product-discounts/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("product-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ProductDiscountDeleteWithKey(key string, version int) (res
 }
 
 // ProductDiscountGetWithKey for type ProductDiscount
-func (client *Client) ProductDiscountGetWithKey(key string) (result *ProductDiscount, err error) {
-	err = client.Get(strings.Replace("product-discounts/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductDiscountGetWithKey(ctx context.Context, key string) (result *ProductDiscount, err error) {
+	err = client.Get(ctx, strings.Replace("product-discounts/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ProductDiscountUpdateWithKeyInput struct {
 }
 
 // ProductDiscountUpdateWithKey for type ProductDiscount
-func (client *Client) ProductDiscountUpdateWithKey(input *ProductDiscountUpdateWithKeyInput) (result *ProductDiscount, err error) {
-	err = client.Update(strings.Replace("product-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductDiscountUpdateWithKey(ctx context.Context, input *ProductDiscountUpdateWithKeyInput) (result *ProductDiscount, err error) {
+	err = client.Update(ctx, strings.Replace("product-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ProductDiscountUpdateWithKey(input *ProductDiscountUpdateW
 }
 
 // ProductDiscountDeleteWithID for type ProductDiscount
-func (client *Client) ProductDiscountDeleteWithID(ID string, version int) (result *ProductDiscount, err error) {
+func (client *Client) ProductDiscountDeleteWithID(ctx context.Context, ID string, version int) (result *ProductDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ProductDiscountDeleteWithID(ID string, version int) (resul
 }
 
 // ProductDiscountGetWithID for type ProductDiscount
-func (client *Client) ProductDiscountGetWithID(ID string) (result *ProductDiscount, err error) {
-	err = client.Get(strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductDiscountGetWithID(ctx context.Context, ID string) (result *ProductDiscount, err error) {
+	err = client.Get(ctx, strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ProductDiscountUpdateWithIDInput struct {
 }
 
 // ProductDiscountUpdateWithID for type ProductDiscount
-func (client *Client) ProductDiscountUpdateWithID(input *ProductDiscountUpdateWithIDInput) (result *ProductDiscount, err error) {
-	err = client.Update(strings.Replace("product-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductDiscountUpdateWithID(ctx context.Context, input *ProductDiscountUpdateWithIDInput) (result *ProductDiscount, err error) {
+	err = client.Update(ctx, strings.Replace("product-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product_test.go
+++ b/commercetools/service_product_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestCreateProductNew(t *testing.T) {
 			"en": "some-product",
 		},
 	}
-	product, err := client.ProductCreate(draft)
+	product, err := client.ProductCreate(context.TODO(), draft)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, product.Version)
 	assert.Equal(t, "Sample description", (*product.MasterData.Current.Description)["en"])
@@ -38,7 +39,7 @@ func TestGetProductByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("product.example.json"), nil, nil)
 	defer server.Close()
 
-	product, err := client.ProductGetWithID("foo-bar")
+	product, err := client.ProductGetWithID(context.TODO(), "foo-bar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +53,7 @@ func TestProductUpdate(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("product.example.json"), nil, nil)
 	defer server.Close()
 
-	product, err := client.ProductUpdateWithID(&commercetools.ProductUpdateWithIDInput{
+	product, err := client.ProductUpdateWithID(context.TODO(), &commercetools.ProductUpdateWithIDInput{
 		ID:      "1",
 		Version: 2,
 		/*
@@ -81,7 +82,7 @@ func TestProductDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("product.example.json"), nil, nil)
 	defer server.Close()
 
-	product, err := client.ProductDeleteWithID("foobar", 2)
+	product, err := client.ProductDeleteWithID(context.TODO(), "foobar", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +95,7 @@ func TestProductDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("product.example.json"), nil, nil)
 	defer server.Close()
 
-	product, err := client.ProductDeleteWithKey("foobar", 2)
+	product, err := client.ProductDeleteWithKey(context.TODO(), "foobar", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +112,7 @@ func TestProductQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ProductQuery(&queryInput)
+	_, err := client.ProductQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_product_type.go
+++ b/commercetools/service_product_type.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ProductTypeURLPath = "product-types"
 
 // ProductTypeCreate creates a new instance of type ProductType
-func (client *Client) ProductTypeCreate(draft *ProductTypeDraft) (result *ProductType, err error) {
-	err = client.Create(ProductTypeURLPath, nil, draft, &result)
+func (client *Client) ProductTypeCreate(ctx context.Context, draft *ProductTypeDraft) (result *ProductType, err error) {
+	err = client.Create(ctx, ProductTypeURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ProductTypeCreate(draft *ProductTypeDraft) (result *Produc
 }
 
 // ProductTypeQuery allows querying for type ProductType
-func (client *Client) ProductTypeQuery(input *QueryInput) (result *ProductTypePagedQueryResponse, err error) {
-	err = client.Query(ProductTypeURLPath, input.toParams(), &result)
+func (client *Client) ProductTypeQuery(ctx context.Context, input *QueryInput) (result *ProductTypePagedQueryResponse, err error) {
+	err = client.Query(ctx, ProductTypeURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ProductTypeQuery(input *QueryInput) (result *ProductTypePa
 }
 
 // ProductTypeDeleteWithKey for type ProductType
-func (client *Client) ProductTypeDeleteWithKey(key string, version int) (result *ProductType, err error) {
+func (client *Client) ProductTypeDeleteWithKey(ctx context.Context, key string, version int) (result *ProductType, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("product-types/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("product-types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ProductTypeDeleteWithKey(key string, version int) (result 
 }
 
 // ProductTypeGetWithKey for type ProductType
-func (client *Client) ProductTypeGetWithKey(key string) (result *ProductType, err error) {
-	err = client.Get(strings.Replace("product-types/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductTypeGetWithKey(ctx context.Context, key string) (result *ProductType, err error) {
+	err = client.Get(ctx, strings.Replace("product-types/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ProductTypeUpdateWithKeyInput struct {
 }
 
 // ProductTypeUpdateWithKey for type ProductType
-func (client *Client) ProductTypeUpdateWithKey(input *ProductTypeUpdateWithKeyInput) (result *ProductType, err error) {
-	err = client.Update(strings.Replace("product-types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductTypeUpdateWithKey(ctx context.Context, input *ProductTypeUpdateWithKeyInput) (result *ProductType, err error) {
+	err = client.Update(ctx, strings.Replace("product-types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ProductTypeUpdateWithKey(input *ProductTypeUpdateWithKeyIn
 }
 
 // ProductTypeDeleteWithID for type ProductType
-func (client *Client) ProductTypeDeleteWithID(ID string, version int) (result *ProductType, err error) {
+func (client *Client) ProductTypeDeleteWithID(ctx context.Context, ID string, version int) (result *ProductType, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("product-types/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("product-types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ProductTypeDeleteWithID(ID string, version int) (result *P
 }
 
 // ProductTypeGetWithID for type ProductType
-func (client *Client) ProductTypeGetWithID(ID string) (result *ProductType, err error) {
-	err = client.Get(strings.Replace("product-types/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductTypeGetWithID(ctx context.Context, ID string) (result *ProductType, err error) {
+	err = client.Get(ctx, strings.Replace("product-types/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ProductTypeUpdateWithIDInput struct {
 }
 
 // ProductTypeUpdateWithID for type ProductType
-func (client *Client) ProductTypeUpdateWithID(input *ProductTypeUpdateWithIDInput) (result *ProductType, err error) {
-	err = client.Update(strings.Replace("product-types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductTypeUpdateWithID(ctx context.Context, input *ProductTypeUpdateWithIDInput) (result *ProductType, err error) {
+	err = client.Update(ctx, strings.Replace("product-types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product_type_test.go
+++ b/commercetools/service_product_type_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -38,7 +39,7 @@ func TestProductTypeCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.ProductTypeCreate(input)
+	_, err := client.ProductTypeCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -646,7 +647,7 @@ func TestProductTypeUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("producttype.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.ProductTypeUpdateWithID(tC.input)
+			_, err := client.ProductTypeUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/product-types/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -660,7 +661,7 @@ func TestProductTypeDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.ProductTypeDeleteWithID("1234", 3)
+	_, err := client.ProductTypeDeleteWithID(context.TODO(), "1234", 3)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -675,7 +676,7 @@ func TestProductTypeDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.ProductTypeDeleteWithKey("1234", 3)
+	_, err := client.ProductTypeDeleteWithKey(context.TODO(), "1234", 3)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -749,7 +750,7 @@ func TestProductTypeGetByID(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture(tC.fixture), nil, nil)
 			defer server.Close()
 
-			result, err := client.ProductTypeGetWithID("1234")
+			result, err := client.ProductTypeGetWithID(context.TODO(), "1234")
 			assert.Nil(t, err)
 			assert.Equal(t, tC.input, result)
 		})
@@ -946,7 +947,7 @@ func TestProductTypeQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ProductTypeQuery(&queryInput)
+	_, err := client.ProductTypeQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_project.go
+++ b/commercetools/service_project.go
@@ -1,5 +1,7 @@
 package commercetools
 
+import "context"
+
 // ProjectUpdateInput provides the data required to update a project.
 type ProjectUpdateInput struct {
 	// The expected version of the project on which the changes should be
@@ -14,7 +16,8 @@ type ProjectUpdateInput struct {
 // ProjectGet will return the current project. OAuth2 Scopes:
 // view_project_settings:{projectKey}
 func (client *Client) ProjectGet() (result *Project, err error) {
-	err = client.Get("", nil, &result)
+	ctx := context.TODO()
+	err = client.Get(ctx, "", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +27,8 @@ func (client *Client) ProjectGet() (result *Project, err error) {
 // ProjectUpdate will update the current project with the defined UpdateActions. OAuth2
 // Scopes: manage_project:{projectKey}
 func (client *Client) ProjectUpdate(input *ProjectUpdateInput) (result *Project, err error) {
-	err = client.Update("", nil, input.Version, input.Actions, &result)
+	ctx := context.TODO()
+	err = client.Update(ctx, "", nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_review.go
+++ b/commercetools/service_review.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ReviewURLPath = "reviews"
 
 // ReviewCreate creates a new instance of type Review
-func (client *Client) ReviewCreate(draft *ReviewDraft) (result *Review, err error) {
-	err = client.Create(ReviewURLPath, nil, draft, &result)
+func (client *Client) ReviewCreate(ctx context.Context, draft *ReviewDraft) (result *Review, err error) {
+	err = client.Create(ctx, ReviewURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ReviewCreate(draft *ReviewDraft) (result *Review, err erro
 }
 
 // ReviewQuery allows querying for type Review
-func (client *Client) ReviewQuery(input *QueryInput) (result *ReviewPagedQueryResponse, err error) {
-	err = client.Query(ReviewURLPath, input.toParams(), &result)
+func (client *Client) ReviewQuery(ctx context.Context, input *QueryInput) (result *ReviewPagedQueryResponse, err error) {
+	err = client.Query(ctx, ReviewURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ReviewQuery(input *QueryInput) (result *ReviewPagedQueryRe
 }
 
 // ReviewDeleteWithKey for type Review
-func (client *Client) ReviewDeleteWithKey(key string, version int, dataErasure bool) (result *Review, err error) {
+func (client *Client) ReviewDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Review, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("reviews/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("reviews/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ReviewDeleteWithKey(key string, version int, dataErasure b
 }
 
 // ReviewGetWithKey for type Review
-func (client *Client) ReviewGetWithKey(key string) (result *Review, err error) {
-	err = client.Get(strings.Replace("reviews/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ReviewGetWithKey(ctx context.Context, key string) (result *Review, err error) {
+	err = client.Get(ctx, strings.Replace("reviews/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ReviewUpdateWithKeyInput struct {
 }
 
 // ReviewUpdateWithKey for type Review
-func (client *Client) ReviewUpdateWithKey(input *ReviewUpdateWithKeyInput) (result *Review, err error) {
-	err = client.Update(strings.Replace("reviews/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ReviewUpdateWithKey(ctx context.Context, input *ReviewUpdateWithKeyInput) (result *Review, err error) {
+	err = client.Update(ctx, strings.Replace("reviews/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ReviewUpdateWithKey(input *ReviewUpdateWithKeyInput) (resu
 }
 
 // ReviewDeleteWithID for type Review
-func (client *Client) ReviewDeleteWithID(ID string, version int, dataErasure bool) (result *Review, err error) {
+func (client *Client) ReviewDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Review, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("reviews/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("reviews/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ReviewDeleteWithID(ID string, version int, dataErasure boo
 }
 
 // ReviewGetWithID for type Review
-func (client *Client) ReviewGetWithID(ID string) (result *Review, err error) {
-	err = client.Get(strings.Replace("reviews/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ReviewGetWithID(ctx context.Context, ID string) (result *Review, err error) {
+	err = client.Get(ctx, strings.Replace("reviews/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ReviewUpdateWithIDInput struct {
 }
 
 // ReviewUpdateWithID for type Review
-func (client *Client) ReviewUpdateWithID(input *ReviewUpdateWithIDInput) (result *Review, err error) {
-	err = client.Update(strings.Replace("reviews/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ReviewUpdateWithID(ctx context.Context, input *ReviewUpdateWithIDInput) (result *Review, err error) {
+	err = client.Update(ctx, strings.Replace("reviews/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_shipping_method.go
+++ b/commercetools/service_shipping_method.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ShippingMethodURLPath = "shipping-methods"
 
 // ShippingMethodCreate creates a new instance of type ShippingMethod
-func (client *Client) ShippingMethodCreate(draft *ShippingMethodDraft) (result *ShippingMethod, err error) {
-	err = client.Create(ShippingMethodURLPath, nil, draft, &result)
+func (client *Client) ShippingMethodCreate(ctx context.Context, draft *ShippingMethodDraft) (result *ShippingMethod, err error) {
+	err = client.Create(ctx, ShippingMethodURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ShippingMethodCreate(draft *ShippingMethodDraft) (result *
 }
 
 // ShippingMethodQuery allows querying for type ShippingMethod
-func (client *Client) ShippingMethodQuery(input *QueryInput) (result *ShippingMethodPagedQueryResponse, err error) {
-	err = client.Query(ShippingMethodURLPath, input.toParams(), &result)
+func (client *Client) ShippingMethodQuery(ctx context.Context, input *QueryInput) (result *ShippingMethodPagedQueryResponse, err error) {
+	err = client.Query(ctx, ShippingMethodURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ShippingMethodQuery(input *QueryInput) (result *ShippingMe
 }
 
 // ShippingMethodDeleteWithKey for type ShippingMethod
-func (client *Client) ShippingMethodDeleteWithKey(key string, version int) (result *ShippingMethod, err error) {
+func (client *Client) ShippingMethodDeleteWithKey(ctx context.Context, key string, version int) (result *ShippingMethod, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("shipping-methods/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("shipping-methods/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ShippingMethodDeleteWithKey(key string, version int) (resu
 }
 
 // ShippingMethodGetWithKey for type ShippingMethod
-func (client *Client) ShippingMethodGetWithKey(key string) (result *ShippingMethod, err error) {
-	err = client.Get(strings.Replace("shipping-methods/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ShippingMethodGetWithKey(ctx context.Context, key string) (result *ShippingMethod, err error) {
+	err = client.Get(ctx, strings.Replace("shipping-methods/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ShippingMethodUpdateWithKeyInput struct {
 }
 
 // ShippingMethodUpdateWithKey for type ShippingMethod
-func (client *Client) ShippingMethodUpdateWithKey(input *ShippingMethodUpdateWithKeyInput) (result *ShippingMethod, err error) {
-	err = client.Update(strings.Replace("shipping-methods/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShippingMethodUpdateWithKey(ctx context.Context, input *ShippingMethodUpdateWithKeyInput) (result *ShippingMethod, err error) {
+	err = client.Update(ctx, strings.Replace("shipping-methods/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ShippingMethodUpdateWithKey(input *ShippingMethodUpdateWit
 }
 
 // ShippingMethodDeleteWithID for type ShippingMethod
-func (client *Client) ShippingMethodDeleteWithID(ID string, version int) (result *ShippingMethod, err error) {
+func (client *Client) ShippingMethodDeleteWithID(ctx context.Context, ID string, version int) (result *ShippingMethod, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ShippingMethodDeleteWithID(ID string, version int) (result
 }
 
 // ShippingMethodGetWithID for type ShippingMethod
-func (client *Client) ShippingMethodGetWithID(ID string) (result *ShippingMethod, err error) {
-	err = client.Get(strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ShippingMethodGetWithID(ctx context.Context, ID string) (result *ShippingMethod, err error) {
+	err = client.Get(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ShippingMethodUpdateWithIDInput struct {
 }
 
 // ShippingMethodUpdateWithID for type ShippingMethod
-func (client *Client) ShippingMethodUpdateWithID(input *ShippingMethodUpdateWithIDInput) (result *ShippingMethod, err error) {
-	err = client.Update(strings.Replace("shipping-methods/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShippingMethodUpdateWithID(ctx context.Context, input *ShippingMethodUpdateWithIDInput) (result *ShippingMethod, err error) {
+	err = client.Update(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_shipping_method_test.go
+++ b/commercetools/service_shipping_method_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"net/url"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ func TestShippingMethodCreate(t *testing.T) {
 		IsDefault:   false,
 	}
 
-	_, err := client.ShippingMethodCreate(input)
+	_, err := client.ShippingMethodCreate(context.TODO(), input)
 	assert.Nil(t, err)
 	expectBody := `{
 		"name": "Shipping method",
@@ -137,7 +138,7 @@ func TestShippingMethodUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("shipping-method.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.ShippingMethodUpdateWithID(tC.input)
+			_, err := client.ShippingMethodUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/shipping-methods/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -150,7 +151,7 @@ func TestShippingMethodDeleteById(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.ShippingMethodDeleteWithID("1234", 2)
+	_, err := client.ShippingMethodDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -174,7 +175,7 @@ func TestShippingMethodGetByID(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.ShippingMethodGetWithID("1234")
+	result, err := client.ShippingMethodGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -193,7 +194,7 @@ func TestShippingMethodGetByKey(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.ShippingMethodGetWithKey("test-shipping-method")
+	result, err := client.ShippingMethodGetWithKey(context.TODO(), "test-shipping-method")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -206,7 +207,7 @@ func TestShippingMethodQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ShippingMethodQuery(&queryInput)
+	_, err := client.ShippingMethodQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_shopping_list.go
+++ b/commercetools/service_shopping_list.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ShoppingListURLPath = "shopping-lists"
 
 // ShoppingListCreate creates a new instance of type ShoppingList
-func (client *Client) ShoppingListCreate(draft *ShoppingListDraft) (result *ShoppingList, err error) {
-	err = client.Create(ShoppingListURLPath, nil, draft, &result)
+func (client *Client) ShoppingListCreate(ctx context.Context, draft *ShoppingListDraft) (result *ShoppingList, err error) {
+	err = client.Create(ctx, ShoppingListURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ShoppingListCreate(draft *ShoppingListDraft) (result *Shop
 }
 
 // ShoppingListQuery allows querying for type ShoppingList
-func (client *Client) ShoppingListQuery(input *QueryInput) (result *ShoppingListPagedQueryResponse, err error) {
-	err = client.Query(ShoppingListURLPath, input.toParams(), &result)
+func (client *Client) ShoppingListQuery(ctx context.Context, input *QueryInput) (result *ShoppingListPagedQueryResponse, err error) {
+	err = client.Query(ctx, ShoppingListURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ShoppingListQuery(input *QueryInput) (result *ShoppingList
 }
 
 // ShoppingListDeleteWithKey for type ShoppingList
-func (client *Client) ShoppingListDeleteWithKey(key string, version int, dataErasure bool) (result *ShoppingList, err error) {
+func (client *Client) ShoppingListDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *ShoppingList, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("shopping-lists/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("shopping-lists/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ShoppingListDeleteWithKey(key string, version int, dataEra
 }
 
 // ShoppingListGetWithKey Gets a shopping list by Key.
-func (client *Client) ShoppingListGetWithKey(key string) (result *ShoppingList, err error) {
-	err = client.Get(strings.Replace("shopping-lists/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ShoppingListGetWithKey(ctx context.Context, key string) (result *ShoppingList, err error) {
+	err = client.Get(ctx, strings.Replace("shopping-lists/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ShoppingListUpdateWithKeyInput struct {
 }
 
 // ShoppingListUpdateWithKey Update a shopping list found by its Key.
-func (client *Client) ShoppingListUpdateWithKey(input *ShoppingListUpdateWithKeyInput) (result *ShoppingList, err error) {
-	err = client.Update(strings.Replace("shopping-lists/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShoppingListUpdateWithKey(ctx context.Context, input *ShoppingListUpdateWithKeyInput) (result *ShoppingList, err error) {
+	err = client.Update(ctx, strings.Replace("shopping-lists/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ShoppingListUpdateWithKey(input *ShoppingListUpdateWithKey
 }
 
 // ShoppingListDeleteWithID for type ShoppingList
-func (client *Client) ShoppingListDeleteWithID(ID string, version int, dataErasure bool) (result *ShoppingList, err error) {
+func (client *Client) ShoppingListDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *ShoppingList, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
-	err = client.Delete(strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ShoppingListDeleteWithID(ID string, version int, dataErasu
 }
 
 // ShoppingListGetWithID Gets a shopping list by ID.
-func (client *Client) ShoppingListGetWithID(ID string) (result *ShoppingList, err error) {
-	err = client.Get(strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ShoppingListGetWithID(ctx context.Context, ID string) (result *ShoppingList, err error) {
+	err = client.Get(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ShoppingListUpdateWithIDInput struct {
 }
 
 // ShoppingListUpdateWithID for type ShoppingList
-func (client *Client) ShoppingListUpdateWithID(input *ShoppingListUpdateWithIDInput) (result *ShoppingList, err error) {
-	err = client.Update(strings.Replace("shopping-lists/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShoppingListUpdateWithID(ctx context.Context, input *ShoppingListUpdateWithIDInput) (result *ShoppingList, err error) {
+	err = client.Update(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_state.go
+++ b/commercetools/service_state.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const StateURLPath = "states"
 
 // StateCreate creates a new instance of type State
-func (client *Client) StateCreate(draft *StateDraft) (result *State, err error) {
-	err = client.Create(StateURLPath, nil, draft, &result)
+func (client *Client) StateCreate(ctx context.Context, draft *StateDraft) (result *State, err error) {
+	err = client.Create(ctx, StateURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) StateCreate(draft *StateDraft) (result *State, err error) 
 }
 
 // StateQuery allows querying for type State
-func (client *Client) StateQuery(input *QueryInput) (result *StatePagedQueryResponse, err error) {
-	err = client.Query(StateURLPath, input.toParams(), &result)
+func (client *Client) StateQuery(ctx context.Context, input *QueryInput) (result *StatePagedQueryResponse, err error) {
+	err = client.Query(ctx, StateURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) StateQuery(input *QueryInput) (result *StatePagedQueryResp
 }
 
 // StateDeleteWithID for type State
-func (client *Client) StateDeleteWithID(ID string, version int) (result *State, err error) {
+func (client *Client) StateDeleteWithID(ctx context.Context, ID string, version int) (result *State, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("states/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("states/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) StateDeleteWithID(ID string, version int) (result *State, 
 }
 
 // StateGetWithID for type State
-func (client *Client) StateGetWithID(ID string) (result *State, err error) {
-	err = client.Get(strings.Replace("states/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) StateGetWithID(ctx context.Context, ID string) (result *State, err error) {
+	err = client.Get(ctx, strings.Replace("states/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type StateUpdateWithIDInput struct {
 }
 
 // StateUpdateWithID for type State
-func (client *Client) StateUpdateWithID(input *StateUpdateWithIDInput) (result *State, err error) {
-	err = client.Update(strings.Replace("states/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StateUpdateWithID(ctx context.Context, input *StateUpdateWithIDInput) (result *State, err error) {
+	err = client.Update(ctx, strings.Replace("states/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_state_test.go
+++ b/commercetools/service_state_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"net/url"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestStateCreate(t *testing.T) {
 		},
 	}
 
-	_, err := client.StateCreate(input)
+	_, err := client.StateCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -292,7 +293,7 @@ func TestStateUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("state.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.StateUpdateWithID(tC.input)
+			_, err := client.StateUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/states/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -305,7 +306,7 @@ func TestStateDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.StateDeleteWithID("1234", 2)
+	_, err := client.StateDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -338,7 +339,7 @@ func TestStateGetByID(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.StateGetWithID("1234")
+	result, err := client.StateGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -351,7 +352,7 @@ func TestStateQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.StateQuery(&queryInput)
+	_, err := client.StateQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_store.go
+++ b/commercetools/service_store.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const StoreURLPath = "stores"
 
 // StoreCreate creates a new instance of type Store
-func (client *Client) StoreCreate(draft *StoreDraft) (result *Store, err error) {
-	err = client.Create(StoreURLPath, nil, draft, &result)
+func (client *Client) StoreCreate(ctx context.Context, draft *StoreDraft) (result *Store, err error) {
+	err = client.Create(ctx, StoreURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) StoreCreate(draft *StoreDraft) (result *Store, err error) 
 }
 
 // StoreQuery allows querying for type Store
-func (client *Client) StoreQuery(input *QueryInput) (result *StorePagedQueryResponse, err error) {
-	err = client.Query(StoreURLPath, input.toParams(), &result)
+func (client *Client) StoreQuery(ctx context.Context, input *QueryInput) (result *StorePagedQueryResponse, err error) {
+	err = client.Query(ctx, StoreURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) StoreQuery(input *QueryInput) (result *StorePagedQueryResp
 }
 
 // StoreDeleteWithKey for type Store
-func (client *Client) StoreDeleteWithKey(key string, version int) (result *Store, err error) {
+func (client *Client) StoreDeleteWithKey(ctx context.Context, key string, version int) (result *Store, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("stores/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("stores/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) StoreDeleteWithKey(key string, version int) (result *Store
 }
 
 // StoreGetWithKey for type Store
-func (client *Client) StoreGetWithKey(key string) (result *Store, err error) {
-	err = client.Get(strings.Replace("stores/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) StoreGetWithKey(ctx context.Context, key string) (result *Store, err error) {
+	err = client.Get(ctx, strings.Replace("stores/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type StoreUpdateWithKeyInput struct {
 }
 
 // StoreUpdateWithKey for type Store
-func (client *Client) StoreUpdateWithKey(input *StoreUpdateWithKeyInput) (result *Store, err error) {
-	err = client.Update(strings.Replace("stores/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StoreUpdateWithKey(ctx context.Context, input *StoreUpdateWithKeyInput) (result *Store, err error) {
+	err = client.Update(ctx, strings.Replace("stores/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) StoreUpdateWithKey(input *StoreUpdateWithKeyInput) (result
 }
 
 // StoreDeleteWithID for type Store
-func (client *Client) StoreDeleteWithID(ID string, version int) (result *Store, err error) {
+func (client *Client) StoreDeleteWithID(ctx context.Context, ID string, version int) (result *Store, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("stores/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("stores/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) StoreDeleteWithID(ID string, version int) (result *Store, 
 }
 
 // StoreGetWithID for type Store
-func (client *Client) StoreGetWithID(ID string) (result *Store, err error) {
-	err = client.Get(strings.Replace("stores/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) StoreGetWithID(ctx context.Context, ID string) (result *Store, err error) {
+	err = client.Get(ctx, strings.Replace("stores/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type StoreUpdateWithIDInput struct {
 }
 
 // StoreUpdateWithID for type Store
-func (client *Client) StoreUpdateWithID(input *StoreUpdateWithIDInput) (result *Store, err error) {
-	err = client.Update(strings.Replace("stores/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StoreUpdateWithID(ctx context.Context, input *StoreUpdateWithIDInput) (result *Store, err error) {
+	err = client.Update(ctx, strings.Replace("stores/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_store_test.go
+++ b/commercetools/service_store_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -24,7 +25,7 @@ func TestStoreCreate(t *testing.T) {
 		},
 	}
 
-	store, err := client.StoreCreate(input)
+	store, err := client.StoreCreate(context.TODO(), input)
 	fmt.Printf("%#v", store)
 	assert.Nil(t, err)
 
@@ -72,7 +73,7 @@ func TestStoreUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, "{}", &output, nil)
 			defer server.Close()
 
-			_, err := client.StoreUpdateWithID(tC.input)
+			_, err := client.StoreUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/stores/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -120,7 +121,7 @@ func TestStoreUpdateByKey(t *testing.T) {
 			client, server := testutil.MockClient(t, "{}", &output, nil)
 			defer server.Close()
 
-			_, err := client.StoreUpdateWithKey(tC.input)
+			_, err := client.StoreUpdateWithKey(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/stores/key=test123", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -133,7 +134,7 @@ func TestStoreDelete(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.StoreDeleteWithID("ba8d47e5-6591-4ca2-af4c-d547f062bf35", 2)
+	_, err := client.StoreDeleteWithID(context.TODO(), "ba8d47e5-6591-4ca2-af4c-d547f062bf35", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -147,7 +148,7 @@ func TestStoreDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.StoreDeleteWithKey("test123", 2)
+	_, err := client.StoreDeleteWithKey(context.TODO(), "test123", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -160,7 +161,7 @@ func TestStoreGetByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("store.json"), nil, nil)
 	defer server.Close()
 
-	store, err := client.StoreGetWithID("ba8d47e5-6591-4ca2-af4c-d547f062bf35")
+	store, err := client.StoreGetWithID(context.TODO(), "ba8d47e5-6591-4ca2-af4c-d547f062bf35")
 
 	assert.Nil(t, err)
 	assert.Equal(t, "ba8d47e5-6591-4ca2-af4c-d547f062bf35", store.ID)
@@ -170,7 +171,7 @@ func TestStoreGetByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("store.json"), nil, nil)
 	defer server.Close()
 
-	store, err := client.StoreGetWithKey("test123")
+	store, err := client.StoreGetWithKey(context.TODO(), "test123")
 
 	assert.Nil(t, err)
 	assert.Equal(t, "ba8d47e5-6591-4ca2-af4c-d547f062bf35", store.ID)
@@ -184,7 +185,7 @@ func TestStoreQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.StoreQuery(&queryInput)
+	_, err := client.StoreQuery(context.TODO(), &queryInput)
 
 	assert.Nil(t, err)
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_subscription.go
+++ b/commercetools/service_subscription.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const SubscriptionURLPath = "subscriptions"
 
 // SubscriptionCreate creates a new instance of type Subscription
-func (client *Client) SubscriptionCreate(draft *SubscriptionDraft) (result *Subscription, err error) {
-	err = client.Create(SubscriptionURLPath, nil, draft, &result)
+func (client *Client) SubscriptionCreate(ctx context.Context, draft *SubscriptionDraft) (result *Subscription, err error) {
+	err = client.Create(ctx, SubscriptionURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) SubscriptionCreate(draft *SubscriptionDraft) (result *Subs
 }
 
 // SubscriptionQuery allows querying for type Subscription
-func (client *Client) SubscriptionQuery(input *QueryInput) (result *SubscriptionPagedQueryResponse, err error) {
-	err = client.Query(SubscriptionURLPath, input.toParams(), &result)
+func (client *Client) SubscriptionQuery(ctx context.Context, input *QueryInput) (result *SubscriptionPagedQueryResponse, err error) {
+	err = client.Query(ctx, SubscriptionURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) SubscriptionQuery(input *QueryInput) (result *Subscription
 }
 
 // SubscriptionDeleteWithKey for type Subscription
-func (client *Client) SubscriptionDeleteWithKey(key string, version int) (result *Subscription, err error) {
+func (client *Client) SubscriptionDeleteWithKey(ctx context.Context, key string, version int) (result *Subscription, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("subscriptions/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("subscriptions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) SubscriptionDeleteWithKey(key string, version int) (result
 }
 
 // SubscriptionGetWithKey Retrieves the representation of a subscription by its key.
-func (client *Client) SubscriptionGetWithKey(key string) (result *Subscription, err error) {
-	err = client.Get(strings.Replace("subscriptions/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) SubscriptionGetWithKey(ctx context.Context, key string) (result *Subscription, err error) {
+	err = client.Get(ctx, strings.Replace("subscriptions/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type SubscriptionUpdateWithKeyInput struct {
 }
 
 // SubscriptionUpdateWithKey for type Subscription
-func (client *Client) SubscriptionUpdateWithKey(input *SubscriptionUpdateWithKeyInput) (result *Subscription, err error) {
-	err = client.Update(strings.Replace("subscriptions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) SubscriptionUpdateWithKey(ctx context.Context, input *SubscriptionUpdateWithKeyInput) (result *Subscription, err error) {
+	err = client.Update(ctx, strings.Replace("subscriptions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) SubscriptionUpdateWithKey(input *SubscriptionUpdateWithKey
 }
 
 // SubscriptionDeleteWithID for type Subscription
-func (client *Client) SubscriptionDeleteWithID(ID string, version int) (result *Subscription, err error) {
+func (client *Client) SubscriptionDeleteWithID(ctx context.Context, ID string, version int) (result *Subscription, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) SubscriptionDeleteWithID(ID string, version int) (result *
 }
 
 // SubscriptionGetWithID Retrieves the representation of a subscription by its id.
-func (client *Client) SubscriptionGetWithID(ID string) (result *Subscription, err error) {
-	err = client.Get(strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) SubscriptionGetWithID(ctx context.Context, ID string) (result *Subscription, err error) {
+	err = client.Get(ctx, strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type SubscriptionUpdateWithIDInput struct {
 }
 
 // SubscriptionUpdateWithID for type Subscription
-func (client *Client) SubscriptionUpdateWithID(input *SubscriptionUpdateWithIDInput) (result *Subscription, err error) {
-	err = client.Update(strings.Replace("subscriptions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) SubscriptionUpdateWithID(ctx context.Context, input *SubscriptionUpdateWithIDInput) (result *Subscription, err error) {
+	err = client.Update(ctx, strings.Replace("subscriptions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_subscription_test.go
+++ b/commercetools/service_subscription_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -215,7 +216,7 @@ func TestSubscriptionCreate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("subscription.sns.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.SubscriptionCreate(tC.input)
+			_, err := client.SubscriptionCreate(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
 		})
@@ -253,7 +254,7 @@ func TestSubscriptionUpdate(t *testing.T) {
 		},
 	}
 
-	_, err := client.SubscriptionUpdateWithID(input)
+	_, err := client.SubscriptionUpdateWithID(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -291,7 +292,7 @@ func TestSubscriptionDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.sns.json"), &output, nil)
 	defer server.Close()
 
-	_, err := client.SubscriptionDeleteWithID("1234", 2)
+	_, err := client.SubscriptionDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -306,7 +307,7 @@ func TestSubscriptionDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.sns.json"), &output, nil)
 	defer server.Close()
 
-	_, err := client.SubscriptionDeleteWithKey("1234", 2)
+	_, err := client.SubscriptionDeleteWithKey(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -318,7 +319,7 @@ func TestSubscriptionGetDestinationInvalid(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.invalid.json"), nil, nil)
 	defer server.Close()
 
-	subscription, err := client.SubscriptionGetWithID("100")
+	subscription, err := client.SubscriptionGetWithID(context.TODO(), "100")
 	assert.NotNil(t, err)
 	assert.Nil(t, subscription)
 }
@@ -327,7 +328,7 @@ func TestSubscriptionGetDestinationUnknown(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.unknown.json"), nil, nil)
 	defer server.Close()
 
-	subscription, err := client.SubscriptionGetWithID("100")
+	subscription, err := client.SubscriptionGetWithID(context.TODO(), "100")
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 	assert.Nil(t, subscription.Destination)
@@ -337,7 +338,7 @@ func TestSubscriptionGetDestinationIronMQ(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.ironmq.json"), nil, nil)
 	defer server.Close()
 
-	subscription, err := client.SubscriptionGetWithID("100")
+	subscription, err := client.SubscriptionGetWithID(context.TODO(), "100")
 	assert.Nil(t, err)
 
 	destination := subscription.Destination.(commercetools.IronMqDestination)
@@ -351,7 +352,7 @@ func TestSubscriptionGetDestinationSNS(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.sns.json"), nil, nil)
 	defer server.Close()
 
-	subscription, err := client.SubscriptionGetWithID("100")
+	subscription, err := client.SubscriptionGetWithID(context.TODO(), "100")
 	assert.Nil(t, err)
 
 	destination := subscription.Destination.(commercetools.SnsDestination)
@@ -367,7 +368,7 @@ func TestSubscriptionGetDestinationSQS(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("subscription.sqs.json"), nil, nil)
 	defer server.Close()
 
-	subscription, err := client.SubscriptionGetWithID("100")
+	subscription, err := client.SubscriptionGetWithID(context.TODO(), "100")
 	assert.Nil(t, err)
 
 	destination := subscription.Destination.(commercetools.SqsDestination)
@@ -387,7 +388,7 @@ func TestSubscriptionTypeQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.SubscriptionQuery(&queryInput)
+	_, err := client.SubscriptionQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_tax_category.go
+++ b/commercetools/service_tax_category.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const TaxCategoryURLPath = "tax-categories"
 
 // TaxCategoryCreate creates a new instance of type TaxCategory
-func (client *Client) TaxCategoryCreate(draft *TaxCategoryDraft) (result *TaxCategory, err error) {
-	err = client.Create(TaxCategoryURLPath, nil, draft, &result)
+func (client *Client) TaxCategoryCreate(ctx context.Context, draft *TaxCategoryDraft) (result *TaxCategory, err error) {
+	err = client.Create(ctx, TaxCategoryURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) TaxCategoryCreate(draft *TaxCategoryDraft) (result *TaxCat
 }
 
 // TaxCategoryQuery allows querying for type TaxCategory
-func (client *Client) TaxCategoryQuery(input *QueryInput) (result *TaxCategoryPagedQueryResponse, err error) {
-	err = client.Query(TaxCategoryURLPath, input.toParams(), &result)
+func (client *Client) TaxCategoryQuery(ctx context.Context, input *QueryInput) (result *TaxCategoryPagedQueryResponse, err error) {
+	err = client.Query(ctx, TaxCategoryURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) TaxCategoryQuery(input *QueryInput) (result *TaxCategoryPa
 }
 
 // TaxCategoryDeleteWithKey for type TaxCategory
-func (client *Client) TaxCategoryDeleteWithKey(key string, version int) (result *TaxCategory, err error) {
+func (client *Client) TaxCategoryDeleteWithKey(ctx context.Context, key string, version int) (result *TaxCategory, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("tax-categories/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("tax-categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) TaxCategoryDeleteWithKey(key string, version int) (result 
 }
 
 // TaxCategoryGetWithKey for type TaxCategory
-func (client *Client) TaxCategoryGetWithKey(key string) (result *TaxCategory, err error) {
-	err = client.Get(strings.Replace("tax-categories/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) TaxCategoryGetWithKey(ctx context.Context, key string) (result *TaxCategory, err error) {
+	err = client.Get(ctx, strings.Replace("tax-categories/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type TaxCategoryUpdateWithKeyInput struct {
 }
 
 // TaxCategoryUpdateWithKey for type TaxCategory
-func (client *Client) TaxCategoryUpdateWithKey(input *TaxCategoryUpdateWithKeyInput) (result *TaxCategory, err error) {
-	err = client.Update(strings.Replace("tax-categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TaxCategoryUpdateWithKey(ctx context.Context, input *TaxCategoryUpdateWithKeyInput) (result *TaxCategory, err error) {
+	err = client.Update(ctx, strings.Replace("tax-categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) TaxCategoryUpdateWithKey(input *TaxCategoryUpdateWithKeyIn
 }
 
 // TaxCategoryDeleteWithID for type TaxCategory
-func (client *Client) TaxCategoryDeleteWithID(ID string, version int) (result *TaxCategory, err error) {
+func (client *Client) TaxCategoryDeleteWithID(ctx context.Context, ID string, version int) (result *TaxCategory, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) TaxCategoryDeleteWithID(ID string, version int) (result *T
 }
 
 // TaxCategoryGetWithID for type TaxCategory
-func (client *Client) TaxCategoryGetWithID(ID string) (result *TaxCategory, err error) {
-	err = client.Get(strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) TaxCategoryGetWithID(ctx context.Context, ID string) (result *TaxCategory, err error) {
+	err = client.Get(ctx, strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type TaxCategoryUpdateWithIDInput struct {
 }
 
 // TaxCategoryUpdateWithID for type TaxCategory
-func (client *Client) TaxCategoryUpdateWithID(input *TaxCategoryUpdateWithIDInput) (result *TaxCategory, err error) {
-	err = client.Update(strings.Replace("tax-categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TaxCategoryUpdateWithID(ctx context.Context, input *TaxCategoryUpdateWithIDInput) (result *TaxCategory, err error) {
+	err = client.Update(ctx, strings.Replace("tax-categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_taxcategory_test.go
+++ b/commercetools/service_taxcategory_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -42,7 +43,7 @@ func TestTaxCategoryCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.TaxCategoryCreate(input)
+	_, err := client.TaxCategoryCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -232,7 +233,7 @@ func TestTaxCategoryUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("tax-category.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.TaxCategoryUpdateWithID(tC.input)
+			_, err := client.TaxCategoryUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/tax-categories/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -245,7 +246,7 @@ func TestTaxCategoryDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.TaxCategoryDeleteWithID("1234", 2)
+	_, err := client.TaxCategoryDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -260,7 +261,7 @@ func TestTaxCategoryDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.TaxCategoryDeleteWithID("1234", 2)
+	_, err := client.TaxCategoryDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -294,7 +295,7 @@ func TestTaxCategoryGetByID(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.TaxCategoryGetWithID("1234")
+	result, err := client.TaxCategoryGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -307,7 +308,7 @@ func TestTaxCategoryQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.TaxCategoryQuery(&queryInput)
+	_, err := client.TaxCategoryQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_type.go
+++ b/commercetools/service_type.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const TypeURLPath = "types"
 
 // TypeCreate creates a new instance of type Type
-func (client *Client) TypeCreate(draft *TypeDraft) (result *Type, err error) {
-	err = client.Create(TypeURLPath, nil, draft, &result)
+func (client *Client) TypeCreate(ctx context.Context, draft *TypeDraft) (result *Type, err error) {
+	err = client.Create(ctx, TypeURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) TypeCreate(draft *TypeDraft) (result *Type, err error) {
 }
 
 // TypeQuery allows querying for type Type
-func (client *Client) TypeQuery(input *QueryInput) (result *TypePagedQueryResponse, err error) {
-	err = client.Query(TypeURLPath, input.toParams(), &result)
+func (client *Client) TypeQuery(ctx context.Context, input *QueryInput) (result *TypePagedQueryResponse, err error) {
+	err = client.Query(ctx, TypeURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) TypeQuery(input *QueryInput) (result *TypePagedQueryRespon
 }
 
 // TypeDeleteWithKey for type Type
-func (client *Client) TypeDeleteWithKey(key string, version int) (result *Type, err error) {
+func (client *Client) TypeDeleteWithKey(ctx context.Context, key string, version int) (result *Type, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("types/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) TypeDeleteWithKey(key string, version int) (result *Type, 
 }
 
 // TypeGetWithKey for type Type
-func (client *Client) TypeGetWithKey(key string) (result *Type, err error) {
-	err = client.Get(strings.Replace("types/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) TypeGetWithKey(ctx context.Context, key string) (result *Type, err error) {
+	err = client.Get(ctx, strings.Replace("types/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type TypeUpdateWithKeyInput struct {
 }
 
 // TypeUpdateWithKey for type Type
-func (client *Client) TypeUpdateWithKey(input *TypeUpdateWithKeyInput) (result *Type, err error) {
-	err = client.Update(strings.Replace("types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TypeUpdateWithKey(ctx context.Context, input *TypeUpdateWithKeyInput) (result *Type, err error) {
+	err = client.Update(ctx, strings.Replace("types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) TypeUpdateWithKey(input *TypeUpdateWithKeyInput) (result *
 }
 
 // TypeDeleteWithID for type Type
-func (client *Client) TypeDeleteWithID(ID string, version int) (result *Type, err error) {
+func (client *Client) TypeDeleteWithID(ctx context.Context, ID string, version int) (result *Type, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("types/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) TypeDeleteWithID(ID string, version int) (result *Type, er
 }
 
 // TypeGetWithID for type Type
-func (client *Client) TypeGetWithID(ID string) (result *Type, err error) {
-	err = client.Get(strings.Replace("types/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) TypeGetWithID(ctx context.Context, ID string) (result *Type, err error) {
+	err = client.Get(ctx, strings.Replace("types/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type TypeUpdateWithIDInput struct {
 }
 
 // TypeUpdateWithID for type Type
-func (client *Client) TypeUpdateWithID(input *TypeUpdateWithIDInput) (result *Type, err error) {
-	err = client.Update(strings.Replace("types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TypeUpdateWithID(ctx context.Context, input *TypeUpdateWithIDInput) (result *Type, err error) {
+	err = client.Update(ctx, strings.Replace("types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_type_test.go
+++ b/commercetools/service_type_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -42,7 +43,7 @@ func TestTypeCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.TypeCreate(input)
+	_, err := client.TypeCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -376,7 +377,7 @@ func TestTypeUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("type.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.TypeUpdateWithID(tC.input)
+			_, err := client.TypeUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/types/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -389,7 +390,7 @@ func TestTypeDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("type.boolean.json"), &output, nil)
 	defer server.Close()
 
-	_, err := client.TypeDeleteWithID("1234", 2)
+	_, err := client.TypeDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -404,7 +405,7 @@ func TestTypeDeleteByKey(t *testing.T) {
 	client, server := testutil.MockClient(t, testutil.Fixture("type.boolean.json"), &output, nil)
 	defer server.Close()
 
-	_, err := client.TypeDeleteWithKey("1234", 2)
+	_, err := client.TypeDeleteWithKey(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -796,7 +797,7 @@ func TestTypeGetByID(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture(tC.fixture), nil, nil)
 			defer server.Close()
 
-			result, err := client.TypeGetWithID("1234")
+			result, err := client.TypeGetWithID(context.TODO(), "1234")
 			assert.Nil(t, err)
 			assert.Equal(t, tC.input, result)
 		})
@@ -973,7 +974,7 @@ func TestTypeQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.TypeQuery(&queryInput)
+	_, err := client.TypeQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())

--- a/commercetools/service_zone.go
+++ b/commercetools/service_zone.go
@@ -3,6 +3,7 @@
 package commercetools
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 const ZoneURLPath = "zones"
 
 // ZoneCreate creates a new instance of type Zone
-func (client *Client) ZoneCreate(draft *ZoneDraft) (result *Zone, err error) {
-	err = client.Create(ZoneURLPath, nil, draft, &result)
+func (client *Client) ZoneCreate(ctx context.Context, draft *ZoneDraft) (result *Zone, err error) {
+	err = client.Create(ctx, ZoneURLPath, nil, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +22,8 @@ func (client *Client) ZoneCreate(draft *ZoneDraft) (result *Zone, err error) {
 }
 
 // ZoneQuery allows querying for type Zone
-func (client *Client) ZoneQuery(input *QueryInput) (result *ZonePagedQueryResponse, err error) {
-	err = client.Query(ZoneURLPath, input.toParams(), &result)
+func (client *Client) ZoneQuery(ctx context.Context, input *QueryInput) (result *ZonePagedQueryResponse, err error) {
+	err = client.Query(ctx, ZoneURLPath, input.toParams(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (client *Client) ZoneQuery(input *QueryInput) (result *ZonePagedQueryRespon
 }
 
 // ZoneDeleteWithKey for type Zone
-func (client *Client) ZoneDeleteWithKey(key string, version int) (result *Zone, err error) {
+func (client *Client) ZoneDeleteWithKey(ctx context.Context, key string, version int) (result *Zone, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("zones/key={key}", "{key}", key, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("zones/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ func (client *Client) ZoneDeleteWithKey(key string, version int) (result *Zone, 
 }
 
 // ZoneGetWithKey for type Zone
-func (client *Client) ZoneGetWithKey(key string) (result *Zone, err error) {
-	err = client.Get(strings.Replace("zones/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ZoneGetWithKey(ctx context.Context, key string) (result *Zone, err error) {
+	err = client.Get(ctx, strings.Replace("zones/key={key}", "{key}", key, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ type ZoneUpdateWithKeyInput struct {
 }
 
 // ZoneUpdateWithKey for type Zone
-func (client *Client) ZoneUpdateWithKey(input *ZoneUpdateWithKeyInput) (result *Zone, err error) {
-	err = client.Update(strings.Replace("zones/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ZoneUpdateWithKey(ctx context.Context, input *ZoneUpdateWithKeyInput) (result *Zone, err error) {
+	err = client.Update(ctx, strings.Replace("zones/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,11 @@ func (client *Client) ZoneUpdateWithKey(input *ZoneUpdateWithKeyInput) (result *
 }
 
 // ZoneDeleteWithID for type Zone
-func (client *Client) ZoneDeleteWithID(ID string, version int) (result *Zone, err error) {
+func (client *Client) ZoneDeleteWithID(ctx context.Context, ID string, version int) (result *Zone, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
-	err = client.Delete(strings.Replace("zones/{ID}", "{ID}", ID, 1), params, &result)
+	err = client.Delete(ctx, strings.Replace("zones/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (client *Client) ZoneDeleteWithID(ID string, version int) (result *Zone, er
 }
 
 // ZoneGetWithID for type Zone
-func (client *Client) ZoneGetWithID(ID string) (result *Zone, err error) {
-	err = client.Get(strings.Replace("zones/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ZoneGetWithID(ctx context.Context, ID string) (result *Zone, err error) {
+	err = client.Get(ctx, strings.Replace("zones/{ID}", "{ID}", ID, 1), nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ type ZoneUpdateWithIDInput struct {
 }
 
 // ZoneUpdateWithID for type Zone
-func (client *Client) ZoneUpdateWithID(input *ZoneUpdateWithIDInput) (result *Zone, err error) {
-	err = client.Update(strings.Replace("zones/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ZoneUpdateWithID(ctx context.Context, input *ZoneUpdateWithIDInput) (result *Zone, err error) {
+	err = client.Update(ctx, strings.Replace("zones/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_zone_test.go
+++ b/commercetools/service_zone_test.go
@@ -1,6 +1,7 @@
 package commercetools_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -31,7 +32,7 @@ func TestZoneCreate(t *testing.T) {
 
 	fmt.Println(output)
 
-	_, err := client.ZoneCreate(input)
+	_, err := client.ZoneCreate(context.TODO(), input)
 	assert.Nil(t, err)
 
 	expectedBody := `{
@@ -157,7 +158,7 @@ func TestZoneUpdate(t *testing.T) {
 			client, server := testutil.MockClient(t, testutil.Fixture("shipping-zone.update.json"), &output, nil)
 			defer server.Close()
 
-			_, err := client.ZoneUpdateWithID(tC.input)
+			_, err := client.ZoneUpdateWithID(context.TODO(), tC.input)
 			assert.Nil(t, err)
 			assert.Equal(t, "/unittest/zones/1234", output.URL.Path)
 			assert.JSONEq(t, tC.requestBody, output.JSON)
@@ -170,7 +171,7 @@ func TestZoneDeleteByID(t *testing.T) {
 	client, server := testutil.MockClient(t, "{}", &output, nil)
 	defer server.Close()
 
-	_, err := client.ZoneDeleteWithID("1234", 2)
+	_, err := client.ZoneDeleteWithID(context.TODO(), "1234", 2)
 	assert.Nil(t, err)
 
 	params := url.Values{}
@@ -198,7 +199,7 @@ func TestZoneGetByID(t *testing.T) {
 		LastModifiedAt: timestamp,
 	}
 
-	result, err := client.ZoneGetWithID("1234")
+	result, err := client.ZoneGetWithID(context.TODO(), "1234")
 	assert.Nil(t, err)
 	assert.Equal(t, input, result)
 }
@@ -211,7 +212,7 @@ func TestZoneQuery(t *testing.T) {
 	queryInput := commercetools.QueryInput{
 		Limit: 500,
 	}
-	_, err := client.ZoneQuery(&queryInput)
+	_, err := client.ZoneQuery(context.TODO(), &queryInput)
 	assert.Nil(t, err)
 
 	assert.Equal(t, url.Values{"limit": []string{"500"}}, output.URL.Query())


### PR DESCRIPTION
This is a backwards incompatible change and affects all service method
calls. By passing a context to every method we can use for example
Cancel and Deadline contexts.

For upgrade purposes you can basically prepend all method parameters
with context.TODO().

E.g.

	client.ProductQuery(&commercetools.QueryInput{})

To
	client.ProductQuery(context.TODO(), &commercetools.QueryInput{})