### PR TITLE
Add support for reference expansion in Create, Update, Delete and Get

### DIFF
--- a/commercetools/client_expand.go
+++ b/commercetools/client_expand.go
@@ -1,0 +1,13 @@
+package commercetools
+
+import "net/url"
+
+type RequestOption func(*url.Values)
+
+func WithReferenceExpansion(references ...string) RequestOption {
+	return func(v *url.Values) {
+		for _, ref := range references {
+			v.Add("expand", ref)
+		}
+	}
+}

--- a/commercetools/client_expand_test.go
+++ b/commercetools/client_expand_test.go
@@ -1,0 +1,88 @@
+package commercetools_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
+	"github.com/labd/commercetools-go-sdk/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientCreateWithReferenceExpansion(t *testing.T) {
+	responseData := "{}"
+	output := testutil.RequestData{}
+	client, server := testutil.MockClient(t, responseData, &output, nil)
+	defer server.Close()
+
+	productDraft := &commercetools.ProductDraft{
+		Key: "test-product",
+		Name: &commercetools.LocalizedString{
+			"nl": "Een test product",
+			"en": "A test product",
+		},
+		ProductType: &commercetools.ProductTypeResourceIdentifier{
+			ID: "my-product-type-id",
+		},
+		Slug: &commercetools.LocalizedString{
+			"nl": "een-test-product",
+			"en": "a-test-product",
+		},
+	}
+
+	product, err := client.ProductCreate(
+		context.TODO(), productDraft,
+		commercetools.WithReferenceExpansion("productType"))
+	assert.NotNil(t, product)
+	assert.NoError(t, err)
+	assert.Equal(t, url.Values(url.Values{"expand": []string{"productType"}}), output.URL.Query())
+}
+
+
+func TestClientGetWithReferenceExpansion(t *testing.T) {
+	responseData := "{}"
+	output := testutil.RequestData{}
+	client, server := testutil.MockClient(t, responseData, &output, nil)
+	defer server.Close()
+
+	product, err := client.ProductGetWithID(
+		context.TODO(), "my-id",
+		commercetools.WithReferenceExpansion("productType"))
+	assert.NotNil(t, product)
+	assert.NoError(t, err)
+	assert.Equal(t, url.Values(url.Values{"expand": []string{"productType"}}), output.URL.Query())
+}
+
+
+func TestClientUpdateWithReferenceExpansion(t *testing.T) {
+	responseData := "{}"
+	output := testutil.RequestData{}
+	client, server := testutil.MockClient(t, responseData, &output, nil)
+	defer server.Close()
+
+	product, err := client.ProductUpdateWithID(
+		context.TODO(), &commercetools.ProductUpdateWithIDInput{
+			ID: "foobar",
+			Version: 10,
+		},
+		commercetools.WithReferenceExpansion("productType", "taxCategory"))
+	assert.NotNil(t, product)
+	assert.NoError(t, err)
+	assert.Equal(t, url.Values(url.Values{"expand": []string{"productType", "taxCategory"}}), output.URL.Query())
+}
+
+
+func TestClientDeleteWithReferenceExpansion(t *testing.T) {
+	responseData := "{}"
+	output := testutil.RequestData{}
+	client, server := testutil.MockClient(t, responseData, &output, nil)
+	defer server.Close()
+
+	product, err := client.ProductDeleteWithID(
+		context.TODO(), "my-id", 10,
+		commercetools.WithReferenceExpansion("productType"))
+	assert.NotNil(t, product)
+	assert.NoError(t, err)
+	assert.Equal(t, url.Values(url.Values{"expand": []string{"productType"}, "version":[]string{"10"}}), output.URL.Query())
+}

--- a/commercetools/service_api_client.go
+++ b/commercetools/service_api_client.go
@@ -12,8 +12,12 @@ import (
 const APIClientURLPath = "api-clients"
 
 // APIClientCreate creates a new instance of type APIClient
-func (client *Client) APIClientCreate(ctx context.Context, draft *APIClientDraft) (result *APIClient, err error) {
-	err = client.Create(ctx, APIClientURLPath, nil, draft, &result)
+func (client *Client) APIClientCreate(ctx context.Context, draft *APIClientDraft, opts ...RequestOption) (result *APIClient, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, APIClientURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -30,9 +34,12 @@ func (client *Client) APIClientQuery(ctx context.Context, input *QueryInput) (re
 }
 
 // APIClientDeleteWithID Delete ApiClient by ID
-func (client *Client) APIClientDeleteWithID(ctx context.Context, ID string) (result *APIClient, err error) {
+func (client *Client) APIClientDeleteWithID(ctx context.Context, ID string, opts ...RequestOption) (result *APIClient, err error) {
 	params := url.Values{}
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("api-clients/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -41,8 +48,12 @@ func (client *Client) APIClientDeleteWithID(ctx context.Context, ID string) (res
 }
 
 // APIClientGetWithID Get ApiClient by ID
-func (client *Client) APIClientGetWithID(ctx context.Context, ID string) (result *APIClient, err error) {
-	err = client.Get(ctx, strings.Replace("api-clients/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) APIClientGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *APIClient, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("api-clients/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_cart.go
+++ b/commercetools/service_cart.go
@@ -13,8 +13,12 @@ import (
 const CartURLPath = "carts"
 
 // CartCreate creates a new instance of type Cart
-func (client *Client) CartCreate(ctx context.Context, draft *CartDraft) (result *Cart, err error) {
-	err = client.Create(ctx, CartURLPath, nil, draft, &result)
+func (client *Client) CartCreate(ctx context.Context, draft *CartDraft, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, CartURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) CartQuery(ctx context.Context, input *QueryInput) (result 
 }
 
 // CartDeleteWithID for type Cart
-func (client *Client) CartDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Cart, err error) {
+func (client *Client) CartDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *Cart, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("carts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -46,8 +53,12 @@ func (client *Client) CartDeleteWithID(ctx context.Context, ID string, version i
 CartGetWithID The cart may not contain up-to-date prices, discounts etc.
 If you want to ensure they’re up-to-date, send an Update request with the Recalculate update action instead.
 */
-func (client *Client) CartGetWithID(ctx context.Context, ID string) (result *Cart, err error) {
-	err = client.Get(ctx, strings.Replace("carts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CartGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("carts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +73,12 @@ type CartUpdateWithIDInput struct {
 }
 
 // CartUpdateWithID for type Cart
-func (client *Client) CartUpdateWithID(ctx context.Context, input *CartUpdateWithIDInput) (result *Cart, err error) {
-	err = client.Update(ctx, strings.Replace("carts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartUpdateWithID(ctx context.Context, input *CartUpdateWithIDInput, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("carts/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_cart_discount.go
+++ b/commercetools/service_cart_discount.go
@@ -13,8 +13,12 @@ import (
 const CartDiscountURLPath = "cart-discounts"
 
 // CartDiscountCreate creates a new instance of type CartDiscount
-func (client *Client) CartDiscountCreate(ctx context.Context, draft *CartDiscountDraft) (result *CartDiscount, err error) {
-	err = client.Create(ctx, CartDiscountURLPath, nil, draft, &result)
+func (client *Client) CartDiscountCreate(ctx context.Context, draft *CartDiscountDraft, opts ...RequestOption) (result *CartDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, CartDiscountURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) CartDiscountQuery(ctx context.Context, input *QueryInput) 
 }
 
 // CartDiscountDeleteWithKey for type CartDiscount
-func (client *Client) CartDiscountDeleteWithKey(ctx context.Context, key string, version int) (result *CartDiscount, err error) {
+func (client *Client) CartDiscountDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *CartDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("cart-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) CartDiscountDeleteWithKey(ctx context.Context, key string,
 }
 
 // CartDiscountGetWithKey for type CartDiscount
-func (client *Client) CartDiscountGetWithKey(ctx context.Context, key string) (result *CartDiscount, err error) {
-	err = client.Get(ctx, strings.Replace("cart-discounts/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CartDiscountGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *CartDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("cart-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type CartDiscountUpdateWithKeyInput struct {
 }
 
 // CartDiscountUpdateWithKey for type CartDiscount
-func (client *Client) CartDiscountUpdateWithKey(ctx context.Context, input *CartDiscountUpdateWithKeyInput) (result *CartDiscount, err error) {
-	err = client.Update(ctx, strings.Replace("cart-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartDiscountUpdateWithKey(ctx context.Context, input *CartDiscountUpdateWithKeyInput, opts ...RequestOption) (result *CartDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("cart-discounts/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) CartDiscountUpdateWithKey(ctx context.Context, input *Cart
 }
 
 // CartDiscountDeleteWithID for type CartDiscount
-func (client *Client) CartDiscountDeleteWithID(ctx context.Context, ID string, version int) (result *CartDiscount, err error) {
+func (client *Client) CartDiscountDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *CartDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) CartDiscountDeleteWithID(ctx context.Context, ID string, v
 }
 
 // CartDiscountGetWithID for type CartDiscount
-func (client *Client) CartDiscountGetWithID(ctx context.Context, ID string) (result *CartDiscount, err error) {
-	err = client.Get(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CartDiscountGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *CartDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type CartDiscountUpdateWithIDInput struct {
 }
 
 // CartDiscountUpdateWithID for type CartDiscount
-func (client *Client) CartDiscountUpdateWithID(ctx context.Context, input *CartDiscountUpdateWithIDInput) (result *CartDiscount, err error) {
-	err = client.Update(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CartDiscountUpdateWithID(ctx context.Context, input *CartDiscountUpdateWithIDInput, opts ...RequestOption) (result *CartDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("cart-discounts/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_category.go
+++ b/commercetools/service_category.go
@@ -13,8 +13,12 @@ import (
 const CategoryURLPath = "categories"
 
 // CategoryCreate creates a new instance of type Category
-func (client *Client) CategoryCreate(ctx context.Context, draft *CategoryDraft) (result *Category, err error) {
-	err = client.Create(ctx, CategoryURLPath, nil, draft, &result)
+func (client *Client) CategoryCreate(ctx context.Context, draft *CategoryDraft, opts ...RequestOption) (result *Category, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, CategoryURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) CategoryQuery(ctx context.Context, input *QueryInput) (res
 }
 
 // CategoryDeleteWithKey for type Category
-func (client *Client) CategoryDeleteWithKey(ctx context.Context, key string, version int) (result *Category, err error) {
+func (client *Client) CategoryDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Category, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) CategoryDeleteWithKey(ctx context.Context, key string, ver
 }
 
 // CategoryGetWithKey for type Category
-func (client *Client) CategoryGetWithKey(ctx context.Context, key string) (result *Category, err error) {
-	err = client.Get(ctx, strings.Replace("categories/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CategoryGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Category, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type CategoryUpdateWithKeyInput struct {
 }
 
 // CategoryUpdateWithKey for type Category
-func (client *Client) CategoryUpdateWithKey(ctx context.Context, input *CategoryUpdateWithKeyInput) (result *Category, err error) {
-	err = client.Update(ctx, strings.Replace("categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CategoryUpdateWithKey(ctx context.Context, input *CategoryUpdateWithKeyInput, opts ...RequestOption) (result *Category, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("categories/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) CategoryUpdateWithKey(ctx context.Context, input *Category
 }
 
 // CategoryDeleteWithID for type Category
-func (client *Client) CategoryDeleteWithID(ctx context.Context, ID string, version int) (result *Category, err error) {
+func (client *Client) CategoryDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Category, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) CategoryDeleteWithID(ctx context.Context, ID string, versi
 }
 
 // CategoryGetWithID for type Category
-func (client *Client) CategoryGetWithID(ctx context.Context, ID string) (result *Category, err error) {
-	err = client.Get(ctx, strings.Replace("categories/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CategoryGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Category, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type CategoryUpdateWithIDInput struct {
 }
 
 // CategoryUpdateWithID for type Category
-func (client *Client) CategoryUpdateWithID(ctx context.Context, input *CategoryUpdateWithIDInput) (result *Category, err error) {
-	err = client.Update(ctx, strings.Replace("categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CategoryUpdateWithID(ctx context.Context, input *CategoryUpdateWithIDInput, opts ...RequestOption) (result *Category, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("categories/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_channel.go
+++ b/commercetools/service_channel.go
@@ -13,8 +13,12 @@ import (
 const ChannelURLPath = "channels"
 
 // ChannelCreate creates a new instance of type Channel
-func (client *Client) ChannelCreate(ctx context.Context, draft *ChannelDraft) (result *Channel, err error) {
-	err = client.Create(ctx, ChannelURLPath, nil, draft, &result)
+func (client *Client) ChannelCreate(ctx context.Context, draft *ChannelDraft, opts ...RequestOption) (result *Channel, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ChannelURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ChannelQuery(ctx context.Context, input *QueryInput) (resu
 }
 
 // ChannelDeleteWithID for type Channel
-func (client *Client) ChannelDeleteWithID(ctx context.Context, ID string, version int) (result *Channel, err error) {
+func (client *Client) ChannelDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Channel, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("channels/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ChannelDeleteWithID(ctx context.Context, ID string, versio
 }
 
 // ChannelGetWithID for type Channel
-func (client *Client) ChannelGetWithID(ctx context.Context, ID string) (result *Channel, err error) {
-	err = client.Get(ctx, strings.Replace("channels/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ChannelGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Channel, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("channels/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ChannelUpdateWithIDInput struct {
 }
 
 // ChannelUpdateWithID for type Channel
-func (client *Client) ChannelUpdateWithID(ctx context.Context, input *ChannelUpdateWithIDInput) (result *Channel, err error) {
-	err = client.Update(ctx, strings.Replace("channels/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ChannelUpdateWithID(ctx context.Context, input *ChannelUpdateWithIDInput, opts ...RequestOption) (result *Channel, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("channels/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_customer.go
+++ b/commercetools/service_customer.go
@@ -13,8 +13,12 @@ import (
 const CustomerURLPath = "customers"
 
 // CustomerCreate creates a new instance of type Customer
-func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft) (result *Customer, err error) {
-	err = client.Create(ctx, CustomerURLPath, nil, draft, &result)
+func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft, opts ...RequestOption) (result *Customer, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, CustomerURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) CustomerQuery(ctx context.Context, input *QueryInput) (res
 }
 
 // CustomerDeleteWithKey for type Customer
-func (client *Client) CustomerDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Customer, err error) {
+func (client *Client) CustomerDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool, opts ...RequestOption) (result *Customer, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("customers/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) CustomerDeleteWithKey(ctx context.Context, key string, ver
 }
 
 // CustomerGetWithKey for type Customer
-func (client *Client) CustomerGetWithKey(ctx context.Context, key string) (result *Customer, err error) {
-	err = client.Get(ctx, strings.Replace("customers/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CustomerGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Customer, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("customers/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type CustomerUpdateWithKeyInput struct {
 }
 
 // CustomerUpdateWithKey for type Customer
-func (client *Client) CustomerUpdateWithKey(ctx context.Context, input *CustomerUpdateWithKeyInput) (result *Customer, err error) {
-	err = client.Update(ctx, strings.Replace("customers/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerUpdateWithKey(ctx context.Context, input *CustomerUpdateWithKeyInput, opts ...RequestOption) (result *Customer, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("customers/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) CustomerUpdateWithKey(ctx context.Context, input *Customer
 }
 
 // CustomerDeleteWithID for type Customer
-func (client *Client) CustomerDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Customer, err error) {
+func (client *Client) CustomerDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *Customer, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("customers/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) CustomerDeleteWithID(ctx context.Context, ID string, versi
 }
 
 // CustomerGetWithID for type Customer
-func (client *Client) CustomerGetWithID(ctx context.Context, ID string) (result *Customer, err error) {
-	err = client.Get(ctx, strings.Replace("customers/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CustomerGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Customer, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("customers/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type CustomerUpdateWithIDInput struct {
 }
 
 // CustomerUpdateWithID for type Customer
-func (client *Client) CustomerUpdateWithID(ctx context.Context, input *CustomerUpdateWithIDInput) (result *Customer, err error) {
-	err = client.Update(ctx, strings.Replace("customers/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerUpdateWithID(ctx context.Context, input *CustomerUpdateWithIDInput, opts ...RequestOption) (result *Customer, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("customers/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_customer_group.go
+++ b/commercetools/service_customer_group.go
@@ -13,8 +13,12 @@ import (
 const CustomerGroupURLPath = "customer-groups"
 
 // CustomerGroupCreate creates a new instance of type CustomerGroup
-func (client *Client) CustomerGroupCreate(ctx context.Context, draft *CustomerGroupDraft) (result *CustomerGroup, err error) {
-	err = client.Create(ctx, CustomerGroupURLPath, nil, draft, &result)
+func (client *Client) CustomerGroupCreate(ctx context.Context, draft *CustomerGroupDraft, opts ...RequestOption) (result *CustomerGroup, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, CustomerGroupURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) CustomerGroupQuery(ctx context.Context, input *QueryInput)
 }
 
 // CustomerGroupDeleteWithKey for type CustomerGroup
-func (client *Client) CustomerGroupDeleteWithKey(ctx context.Context, key string, version int) (result *CustomerGroup, err error) {
+func (client *Client) CustomerGroupDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *CustomerGroup, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("customer-groups/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) CustomerGroupDeleteWithKey(ctx context.Context, key string
 }
 
 // CustomerGroupGetWithKey Gets a customer group by Key.
-func (client *Client) CustomerGroupGetWithKey(ctx context.Context, key string) (result *CustomerGroup, err error) {
-	err = client.Get(ctx, strings.Replace("customer-groups/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) CustomerGroupGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *CustomerGroup, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("customer-groups/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type CustomerGroupUpdateWithKeyInput struct {
 }
 
 // CustomerGroupUpdateWithKey Updates a customer group by Key.
-func (client *Client) CustomerGroupUpdateWithKey(ctx context.Context, input *CustomerGroupUpdateWithKeyInput) (result *CustomerGroup, err error) {
-	err = client.Update(ctx, strings.Replace("customer-groups/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerGroupUpdateWithKey(ctx context.Context, input *CustomerGroupUpdateWithKeyInput, opts ...RequestOption) (result *CustomerGroup, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("customer-groups/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) CustomerGroupUpdateWithKey(ctx context.Context, input *Cus
 }
 
 // CustomerGroupDeleteWithID for type CustomerGroup
-func (client *Client) CustomerGroupDeleteWithID(ctx context.Context, ID string, version int) (result *CustomerGroup, err error) {
+func (client *Client) CustomerGroupDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *CustomerGroup, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) CustomerGroupDeleteWithID(ctx context.Context, ID string, 
 }
 
 // CustomerGroupGetWithID for type CustomerGroup
-func (client *Client) CustomerGroupGetWithID(ctx context.Context, ID string) (result *CustomerGroup, err error) {
-	err = client.Get(ctx, strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) CustomerGroupGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *CustomerGroup, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("customer-groups/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type CustomerGroupUpdateWithIDInput struct {
 }
 
 // CustomerGroupUpdateWithID for type CustomerGroup
-func (client *Client) CustomerGroupUpdateWithID(ctx context.Context, input *CustomerGroupUpdateWithIDInput) (result *CustomerGroup, err error) {
-	err = client.Update(ctx, strings.Replace("customer-groups/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) CustomerGroupUpdateWithID(ctx context.Context, input *CustomerGroupUpdateWithIDInput, opts ...RequestOption) (result *CustomerGroup, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("customer-groups/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_discount_code.go
+++ b/commercetools/service_discount_code.go
@@ -13,8 +13,12 @@ import (
 const DiscountCodeURLPath = "discount-codes"
 
 // DiscountCodeCreate creates a new instance of type DiscountCode
-func (client *Client) DiscountCodeCreate(ctx context.Context, draft *DiscountCodeDraft) (result *DiscountCode, err error) {
-	err = client.Create(ctx, DiscountCodeURLPath, nil, draft, &result)
+func (client *Client) DiscountCodeCreate(ctx context.Context, draft *DiscountCodeDraft, opts ...RequestOption) (result *DiscountCode, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, DiscountCodeURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) DiscountCodeQuery(ctx context.Context, input *QueryInput) 
 }
 
 // DiscountCodeDeleteWithID for type DiscountCode
-func (client *Client) DiscountCodeDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *DiscountCode, err error) {
+func (client *Client) DiscountCodeDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *DiscountCode, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) DiscountCodeDeleteWithID(ctx context.Context, ID string, v
 }
 
 // DiscountCodeGetWithID for type DiscountCode
-func (client *Client) DiscountCodeGetWithID(ctx context.Context, ID string) (result *DiscountCode, err error) {
-	err = client.Get(ctx, strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) DiscountCodeGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *DiscountCode, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("discount-codes/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type DiscountCodeUpdateWithIDInput struct {
 }
 
 // DiscountCodeUpdateWithID for type DiscountCode
-func (client *Client) DiscountCodeUpdateWithID(ctx context.Context, input *DiscountCodeUpdateWithIDInput) (result *DiscountCode, err error) {
-	err = client.Update(ctx, strings.Replace("discount-codes/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) DiscountCodeUpdateWithID(ctx context.Context, input *DiscountCodeUpdateWithIDInput, opts ...RequestOption) (result *DiscountCode, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("discount-codes/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_extension.go
+++ b/commercetools/service_extension.go
@@ -13,8 +13,12 @@ import (
 const ExtensionURLPath = "extensions"
 
 // ExtensionCreate creates a new instance of type Extension
-func (client *Client) ExtensionCreate(ctx context.Context, draft *ExtensionDraft) (result *Extension, err error) {
-	err = client.Create(ctx, ExtensionURLPath, nil, draft, &result)
+func (client *Client) ExtensionCreate(ctx context.Context, draft *ExtensionDraft, opts ...RequestOption) (result *Extension, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ExtensionURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ExtensionQuery(ctx context.Context, input *QueryInput) (re
 }
 
 // ExtensionDeleteWithKey for type Extension
-func (client *Client) ExtensionDeleteWithKey(ctx context.Context, key string, version int) (result *Extension, err error) {
+func (client *Client) ExtensionDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Extension, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("extensions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ExtensionDeleteWithKey(ctx context.Context, key string, ve
 }
 
 // ExtensionGetWithKey Retrieves the representation of an extension by its key.
-func (client *Client) ExtensionGetWithKey(ctx context.Context, key string) (result *Extension, err error) {
-	err = client.Get(ctx, strings.Replace("extensions/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ExtensionGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Extension, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("extensions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ExtensionUpdateWithKeyInput struct {
 }
 
 // ExtensionUpdateWithKey for type Extension
-func (client *Client) ExtensionUpdateWithKey(ctx context.Context, input *ExtensionUpdateWithKeyInput) (result *Extension, err error) {
-	err = client.Update(ctx, strings.Replace("extensions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ExtensionUpdateWithKey(ctx context.Context, input *ExtensionUpdateWithKeyInput, opts ...RequestOption) (result *Extension, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("extensions/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ExtensionUpdateWithKey(ctx context.Context, input *Extensi
 }
 
 // ExtensionDeleteWithID for type Extension
-func (client *Client) ExtensionDeleteWithID(ctx context.Context, ID string, version int) (result *Extension, err error) {
+func (client *Client) ExtensionDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Extension, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("extensions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ExtensionDeleteWithID(ctx context.Context, ID string, vers
 }
 
 // ExtensionGetWithID Retrieves the representation of an extension by its id.
-func (client *Client) ExtensionGetWithID(ctx context.Context, ID string) (result *Extension, err error) {
-	err = client.Get(ctx, strings.Replace("extensions/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ExtensionGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Extension, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("extensions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ExtensionUpdateWithIDInput struct {
 }
 
 // ExtensionUpdateWithID for type Extension
-func (client *Client) ExtensionUpdateWithID(ctx context.Context, input *ExtensionUpdateWithIDInput) (result *Extension, err error) {
-	err = client.Update(ctx, strings.Replace("extensions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ExtensionUpdateWithID(ctx context.Context, input *ExtensionUpdateWithIDInput, opts ...RequestOption) (result *Extension, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("extensions/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_inventory.go
+++ b/commercetools/service_inventory.go
@@ -13,8 +13,12 @@ import (
 const InventoryEntryURLPath = "inventory"
 
 // InventoryEntryCreate creates a new instance of type InventoryEntry
-func (client *Client) InventoryEntryCreate(ctx context.Context, draft *InventoryEntryDraft) (result *InventoryEntry, err error) {
-	err = client.Create(ctx, InventoryEntryURLPath, nil, draft, &result)
+func (client *Client) InventoryEntryCreate(ctx context.Context, draft *InventoryEntryDraft, opts ...RequestOption) (result *InventoryEntry, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, InventoryEntryURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) InventoryEntryQuery(ctx context.Context, input *QueryInput
 }
 
 // InventoryEntryDeleteWithID for type InventoryEntry
-func (client *Client) InventoryEntryDeleteWithID(ctx context.Context, ID string, version int) (result *InventoryEntry, err error) {
+func (client *Client) InventoryEntryDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *InventoryEntry, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("inventory/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) InventoryEntryDeleteWithID(ctx context.Context, ID string,
 }
 
 // InventoryEntryGetWithID for type InventoryEntry
-func (client *Client) InventoryEntryGetWithID(ctx context.Context, ID string) (result *InventoryEntry, err error) {
-	err = client.Get(ctx, strings.Replace("inventory/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) InventoryEntryGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *InventoryEntry, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("inventory/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type InventoryEntryUpdateWithIDInput struct {
 }
 
 // InventoryEntryUpdateWithID for type InventoryEntry
-func (client *Client) InventoryEntryUpdateWithID(ctx context.Context, input *InventoryEntryUpdateWithIDInput) (result *InventoryEntry, err error) {
-	err = client.Update(ctx, strings.Replace("inventory/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) InventoryEntryUpdateWithID(ctx context.Context, input *InventoryEntryUpdateWithIDInput, opts ...RequestOption) (result *InventoryEntry, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("inventory/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_message.go
+++ b/commercetools/service_message.go
@@ -4,6 +4,7 @@ package commercetools
 
 import (
 	"context"
+	"net/url"
 	"strings"
 )
 
@@ -20,8 +21,12 @@ func (client *Client) AbstractMessageQuery(ctx context.Context, input *QueryInpu
 }
 
 // AbstractMessageGetWithID for type Message
-func (client *Client) AbstractMessageGetWithID(ctx context.Context, ID string) (result *Message, err error) {
-	err = client.Get(ctx, strings.Replace("messages/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) AbstractMessageGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Message, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("messages/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_order.go
+++ b/commercetools/service_order.go
@@ -13,8 +13,12 @@ import (
 const OrderURLPath = "orders"
 
 // OrderCreate creates a new instance of type Order
-func (client *Client) OrderCreate(ctx context.Context, draft *OrderFromCartDraft) (result *Order, err error) {
-	err = client.Create(ctx, OrderURLPath, nil, draft, &result)
+func (client *Client) OrderCreate(ctx context.Context, draft *OrderFromCartDraft, opts ...RequestOption) (result *Order, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, OrderURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) OrderQuery(ctx context.Context, input *QueryInput) (result
 }
 
 // OrderDeleteWithID for type Order
-func (client *Client) OrderDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Order, err error) {
+func (client *Client) OrderDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *Order, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("orders/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) OrderDeleteWithID(ctx context.Context, ID string, version 
 }
 
 // OrderGetWithID for type Order
-func (client *Client) OrderGetWithID(ctx context.Context, ID string) (result *Order, err error) {
-	err = client.Get(ctx, strings.Replace("orders/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) OrderGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Order, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("orders/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type OrderUpdateWithIDInput struct {
 }
 
 // OrderUpdateWithID for type Order
-func (client *Client) OrderUpdateWithID(ctx context.Context, input *OrderUpdateWithIDInput) (result *Order, err error) {
-	err = client.Update(ctx, strings.Replace("orders/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) OrderUpdateWithID(ctx context.Context, input *OrderUpdateWithIDInput, opts ...RequestOption) (result *Order, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("orders/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_payment.go
+++ b/commercetools/service_payment.go
@@ -13,8 +13,12 @@ import (
 const PaymentURLPath = "payments"
 
 // PaymentCreate creates a new instance of type Payment
-func (client *Client) PaymentCreate(ctx context.Context, draft *PaymentDraft) (result *Payment, err error) {
-	err = client.Create(ctx, PaymentURLPath, nil, draft, &result)
+func (client *Client) PaymentCreate(ctx context.Context, draft *PaymentDraft, opts ...RequestOption) (result *Payment, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, PaymentURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) PaymentQuery(ctx context.Context, input *QueryInput) (resu
 }
 
 // PaymentDeleteWithKey for type Payment
-func (client *Client) PaymentDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Payment, err error) {
+func (client *Client) PaymentDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool, opts ...RequestOption) (result *Payment, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("payments/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) PaymentDeleteWithKey(ctx context.Context, key string, vers
 }
 
 // PaymentGetWithKey for type Payment
-func (client *Client) PaymentGetWithKey(ctx context.Context, key string) (result *Payment, err error) {
-	err = client.Get(ctx, strings.Replace("payments/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) PaymentGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Payment, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("payments/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type PaymentUpdateWithKeyInput struct {
 }
 
 // PaymentUpdateWithKey for type Payment
-func (client *Client) PaymentUpdateWithKey(ctx context.Context, input *PaymentUpdateWithKeyInput) (result *Payment, err error) {
-	err = client.Update(ctx, strings.Replace("payments/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) PaymentUpdateWithKey(ctx context.Context, input *PaymentUpdateWithKeyInput, opts ...RequestOption) (result *Payment, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("payments/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) PaymentUpdateWithKey(ctx context.Context, input *PaymentUp
 }
 
 // PaymentDeleteWithID for type Payment
-func (client *Client) PaymentDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Payment, err error) {
+func (client *Client) PaymentDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *Payment, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("payments/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) PaymentDeleteWithID(ctx context.Context, ID string, versio
 }
 
 // PaymentGetWithID for type Payment
-func (client *Client) PaymentGetWithID(ctx context.Context, ID string) (result *Payment, err error) {
-	err = client.Get(ctx, strings.Replace("payments/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) PaymentGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Payment, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("payments/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type PaymentUpdateWithIDInput struct {
 }
 
 // PaymentUpdateWithID for type Payment
-func (client *Client) PaymentUpdateWithID(ctx context.Context, input *PaymentUpdateWithIDInput) (result *Payment, err error) {
-	err = client.Update(ctx, strings.Replace("payments/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) PaymentUpdateWithID(ctx context.Context, input *PaymentUpdateWithIDInput, opts ...RequestOption) (result *Payment, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("payments/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product.go
+++ b/commercetools/service_product.go
@@ -13,8 +13,12 @@ import (
 const ProductURLPath = "products"
 
 // ProductCreate creates a new instance of type Product
-func (client *Client) ProductCreate(ctx context.Context, draft *ProductDraft) (result *Product, err error) {
-	err = client.Create(ctx, ProductURLPath, nil, draft, &result)
+func (client *Client) ProductCreate(ctx context.Context, draft *ProductDraft, opts ...RequestOption) (result *Product, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ProductURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ProductQuery(ctx context.Context, input *QueryInput) (resu
 }
 
 // ProductDeleteWithKey for type Product
-func (client *Client) ProductDeleteWithKey(ctx context.Context, key string, version int) (result *Product, err error) {
+func (client *Client) ProductDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Product, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("products/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ProductDeleteWithKey(ctx context.Context, key string, vers
 }
 
 // ProductGetWithKey Gets the full representation of a product by Key.
-func (client *Client) ProductGetWithKey(ctx context.Context, key string) (result *Product, err error) {
-	err = client.Get(ctx, strings.Replace("products/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Product, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("products/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ProductUpdateWithKeyInput struct {
 }
 
 // ProductUpdateWithKey for type Product
-func (client *Client) ProductUpdateWithKey(ctx context.Context, input *ProductUpdateWithKeyInput) (result *Product, err error) {
-	err = client.Update(ctx, strings.Replace("products/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductUpdateWithKey(ctx context.Context, input *ProductUpdateWithKeyInput, opts ...RequestOption) (result *Product, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("products/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ProductUpdateWithKey(ctx context.Context, input *ProductUp
 }
 
 // ProductDeleteWithID for type Product
-func (client *Client) ProductDeleteWithID(ctx context.Context, ID string, version int) (result *Product, err error) {
+func (client *Client) ProductDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Product, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("products/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ProductDeleteWithID(ctx context.Context, ID string, versio
 }
 
 // ProductGetWithID Gets the full representation of a product by ID.
-func (client *Client) ProductGetWithID(ctx context.Context, ID string) (result *Product, err error) {
-	err = client.Get(ctx, strings.Replace("products/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Product, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("products/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ProductUpdateWithIDInput struct {
 }
 
 // ProductUpdateWithID for type Product
-func (client *Client) ProductUpdateWithID(ctx context.Context, input *ProductUpdateWithIDInput) (result *Product, err error) {
-	err = client.Update(ctx, strings.Replace("products/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductUpdateWithID(ctx context.Context, input *ProductUpdateWithIDInput, opts ...RequestOption) (result *Product, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("products/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product_discount.go
+++ b/commercetools/service_product_discount.go
@@ -13,8 +13,12 @@ import (
 const ProductDiscountURLPath = "product-discounts"
 
 // ProductDiscountCreate creates a new instance of type ProductDiscount
-func (client *Client) ProductDiscountCreate(ctx context.Context, draft *ProductDiscountDraft) (result *ProductDiscount, err error) {
-	err = client.Create(ctx, ProductDiscountURLPath, nil, draft, &result)
+func (client *Client) ProductDiscountCreate(ctx context.Context, draft *ProductDiscountDraft, opts ...RequestOption) (result *ProductDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ProductDiscountURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ProductDiscountQuery(ctx context.Context, input *QueryInpu
 }
 
 // ProductDiscountDeleteWithKey for type ProductDiscount
-func (client *Client) ProductDiscountDeleteWithKey(ctx context.Context, key string, version int) (result *ProductDiscount, err error) {
+func (client *Client) ProductDiscountDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *ProductDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("product-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ProductDiscountDeleteWithKey(ctx context.Context, key stri
 }
 
 // ProductDiscountGetWithKey for type ProductDiscount
-func (client *Client) ProductDiscountGetWithKey(ctx context.Context, key string) (result *ProductDiscount, err error) {
-	err = client.Get(ctx, strings.Replace("product-discounts/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductDiscountGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *ProductDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("product-discounts/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ProductDiscountUpdateWithKeyInput struct {
 }
 
 // ProductDiscountUpdateWithKey for type ProductDiscount
-func (client *Client) ProductDiscountUpdateWithKey(ctx context.Context, input *ProductDiscountUpdateWithKeyInput) (result *ProductDiscount, err error) {
-	err = client.Update(ctx, strings.Replace("product-discounts/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductDiscountUpdateWithKey(ctx context.Context, input *ProductDiscountUpdateWithKeyInput, opts ...RequestOption) (result *ProductDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("product-discounts/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ProductDiscountUpdateWithKey(ctx context.Context, input *P
 }
 
 // ProductDiscountDeleteWithID for type ProductDiscount
-func (client *Client) ProductDiscountDeleteWithID(ctx context.Context, ID string, version int) (result *ProductDiscount, err error) {
+func (client *Client) ProductDiscountDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *ProductDiscount, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ProductDiscountDeleteWithID(ctx context.Context, ID string
 }
 
 // ProductDiscountGetWithID for type ProductDiscount
-func (client *Client) ProductDiscountGetWithID(ctx context.Context, ID string) (result *ProductDiscount, err error) {
-	err = client.Get(ctx, strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductDiscountGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *ProductDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("product-discounts/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ProductDiscountUpdateWithIDInput struct {
 }
 
 // ProductDiscountUpdateWithID for type ProductDiscount
-func (client *Client) ProductDiscountUpdateWithID(ctx context.Context, input *ProductDiscountUpdateWithIDInput) (result *ProductDiscount, err error) {
-	err = client.Update(ctx, strings.Replace("product-discounts/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductDiscountUpdateWithID(ctx context.Context, input *ProductDiscountUpdateWithIDInput, opts ...RequestOption) (result *ProductDiscount, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("product-discounts/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_product_type.go
+++ b/commercetools/service_product_type.go
@@ -13,8 +13,12 @@ import (
 const ProductTypeURLPath = "product-types"
 
 // ProductTypeCreate creates a new instance of type ProductType
-func (client *Client) ProductTypeCreate(ctx context.Context, draft *ProductTypeDraft) (result *ProductType, err error) {
-	err = client.Create(ctx, ProductTypeURLPath, nil, draft, &result)
+func (client *Client) ProductTypeCreate(ctx context.Context, draft *ProductTypeDraft, opts ...RequestOption) (result *ProductType, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ProductTypeURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ProductTypeQuery(ctx context.Context, input *QueryInput) (
 }
 
 // ProductTypeDeleteWithKey for type ProductType
-func (client *Client) ProductTypeDeleteWithKey(ctx context.Context, key string, version int) (result *ProductType, err error) {
+func (client *Client) ProductTypeDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *ProductType, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("product-types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ProductTypeDeleteWithKey(ctx context.Context, key string, 
 }
 
 // ProductTypeGetWithKey for type ProductType
-func (client *Client) ProductTypeGetWithKey(ctx context.Context, key string) (result *ProductType, err error) {
-	err = client.Get(ctx, strings.Replace("product-types/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ProductTypeGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *ProductType, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("product-types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ProductTypeUpdateWithKeyInput struct {
 }
 
 // ProductTypeUpdateWithKey for type ProductType
-func (client *Client) ProductTypeUpdateWithKey(ctx context.Context, input *ProductTypeUpdateWithKeyInput) (result *ProductType, err error) {
-	err = client.Update(ctx, strings.Replace("product-types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductTypeUpdateWithKey(ctx context.Context, input *ProductTypeUpdateWithKeyInput, opts ...RequestOption) (result *ProductType, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("product-types/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ProductTypeUpdateWithKey(ctx context.Context, input *Produ
 }
 
 // ProductTypeDeleteWithID for type ProductType
-func (client *Client) ProductTypeDeleteWithID(ctx context.Context, ID string, version int) (result *ProductType, err error) {
+func (client *Client) ProductTypeDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *ProductType, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("product-types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ProductTypeDeleteWithID(ctx context.Context, ID string, ve
 }
 
 // ProductTypeGetWithID for type ProductType
-func (client *Client) ProductTypeGetWithID(ctx context.Context, ID string) (result *ProductType, err error) {
-	err = client.Get(ctx, strings.Replace("product-types/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ProductTypeGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *ProductType, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("product-types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ProductTypeUpdateWithIDInput struct {
 }
 
 // ProductTypeUpdateWithID for type ProductType
-func (client *Client) ProductTypeUpdateWithID(ctx context.Context, input *ProductTypeUpdateWithIDInput) (result *ProductType, err error) {
-	err = client.Update(ctx, strings.Replace("product-types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ProductTypeUpdateWithID(ctx context.Context, input *ProductTypeUpdateWithIDInput, opts ...RequestOption) (result *ProductType, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("product-types/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_review.go
+++ b/commercetools/service_review.go
@@ -13,8 +13,12 @@ import (
 const ReviewURLPath = "reviews"
 
 // ReviewCreate creates a new instance of type Review
-func (client *Client) ReviewCreate(ctx context.Context, draft *ReviewDraft) (result *Review, err error) {
-	err = client.Create(ctx, ReviewURLPath, nil, draft, &result)
+func (client *Client) ReviewCreate(ctx context.Context, draft *ReviewDraft, opts ...RequestOption) (result *Review, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ReviewURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ReviewQuery(ctx context.Context, input *QueryInput) (resul
 }
 
 // ReviewDeleteWithKey for type Review
-func (client *Client) ReviewDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *Review, err error) {
+func (client *Client) ReviewDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool, opts ...RequestOption) (result *Review, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("reviews/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ReviewDeleteWithKey(ctx context.Context, key string, versi
 }
 
 // ReviewGetWithKey for type Review
-func (client *Client) ReviewGetWithKey(ctx context.Context, key string) (result *Review, err error) {
-	err = client.Get(ctx, strings.Replace("reviews/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ReviewGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Review, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("reviews/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ReviewUpdateWithKeyInput struct {
 }
 
 // ReviewUpdateWithKey for type Review
-func (client *Client) ReviewUpdateWithKey(ctx context.Context, input *ReviewUpdateWithKeyInput) (result *Review, err error) {
-	err = client.Update(ctx, strings.Replace("reviews/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ReviewUpdateWithKey(ctx context.Context, input *ReviewUpdateWithKeyInput, opts ...RequestOption) (result *Review, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("reviews/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ReviewUpdateWithKey(ctx context.Context, input *ReviewUpda
 }
 
 // ReviewDeleteWithID for type Review
-func (client *Client) ReviewDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *Review, err error) {
+func (client *Client) ReviewDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *Review, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("reviews/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ReviewDeleteWithID(ctx context.Context, ID string, version
 }
 
 // ReviewGetWithID for type Review
-func (client *Client) ReviewGetWithID(ctx context.Context, ID string) (result *Review, err error) {
-	err = client.Get(ctx, strings.Replace("reviews/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ReviewGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Review, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("reviews/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ReviewUpdateWithIDInput struct {
 }
 
 // ReviewUpdateWithID for type Review
-func (client *Client) ReviewUpdateWithID(ctx context.Context, input *ReviewUpdateWithIDInput) (result *Review, err error) {
-	err = client.Update(ctx, strings.Replace("reviews/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ReviewUpdateWithID(ctx context.Context, input *ReviewUpdateWithIDInput, opts ...RequestOption) (result *Review, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("reviews/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_shipping_method.go
+++ b/commercetools/service_shipping_method.go
@@ -13,8 +13,12 @@ import (
 const ShippingMethodURLPath = "shipping-methods"
 
 // ShippingMethodCreate creates a new instance of type ShippingMethod
-func (client *Client) ShippingMethodCreate(ctx context.Context, draft *ShippingMethodDraft) (result *ShippingMethod, err error) {
-	err = client.Create(ctx, ShippingMethodURLPath, nil, draft, &result)
+func (client *Client) ShippingMethodCreate(ctx context.Context, draft *ShippingMethodDraft, opts ...RequestOption) (result *ShippingMethod, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ShippingMethodURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ShippingMethodQuery(ctx context.Context, input *QueryInput
 }
 
 // ShippingMethodDeleteWithKey for type ShippingMethod
-func (client *Client) ShippingMethodDeleteWithKey(ctx context.Context, key string, version int) (result *ShippingMethod, err error) {
+func (client *Client) ShippingMethodDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *ShippingMethod, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("shipping-methods/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ShippingMethodDeleteWithKey(ctx context.Context, key strin
 }
 
 // ShippingMethodGetWithKey for type ShippingMethod
-func (client *Client) ShippingMethodGetWithKey(ctx context.Context, key string) (result *ShippingMethod, err error) {
-	err = client.Get(ctx, strings.Replace("shipping-methods/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ShippingMethodGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *ShippingMethod, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("shipping-methods/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ShippingMethodUpdateWithKeyInput struct {
 }
 
 // ShippingMethodUpdateWithKey for type ShippingMethod
-func (client *Client) ShippingMethodUpdateWithKey(ctx context.Context, input *ShippingMethodUpdateWithKeyInput) (result *ShippingMethod, err error) {
-	err = client.Update(ctx, strings.Replace("shipping-methods/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShippingMethodUpdateWithKey(ctx context.Context, input *ShippingMethodUpdateWithKeyInput, opts ...RequestOption) (result *ShippingMethod, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("shipping-methods/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ShippingMethodUpdateWithKey(ctx context.Context, input *Sh
 }
 
 // ShippingMethodDeleteWithID for type ShippingMethod
-func (client *Client) ShippingMethodDeleteWithID(ctx context.Context, ID string, version int) (result *ShippingMethod, err error) {
+func (client *Client) ShippingMethodDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *ShippingMethod, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ShippingMethodDeleteWithID(ctx context.Context, ID string,
 }
 
 // ShippingMethodGetWithID for type ShippingMethod
-func (client *Client) ShippingMethodGetWithID(ctx context.Context, ID string) (result *ShippingMethod, err error) {
-	err = client.Get(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ShippingMethodGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *ShippingMethod, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ShippingMethodUpdateWithIDInput struct {
 }
 
 // ShippingMethodUpdateWithID for type ShippingMethod
-func (client *Client) ShippingMethodUpdateWithID(ctx context.Context, input *ShippingMethodUpdateWithIDInput) (result *ShippingMethod, err error) {
-	err = client.Update(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShippingMethodUpdateWithID(ctx context.Context, input *ShippingMethodUpdateWithIDInput, opts ...RequestOption) (result *ShippingMethod, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("shipping-methods/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_shopping_list.go
+++ b/commercetools/service_shopping_list.go
@@ -13,8 +13,12 @@ import (
 const ShoppingListURLPath = "shopping-lists"
 
 // ShoppingListCreate creates a new instance of type ShoppingList
-func (client *Client) ShoppingListCreate(ctx context.Context, draft *ShoppingListDraft) (result *ShoppingList, err error) {
-	err = client.Create(ctx, ShoppingListURLPath, nil, draft, &result)
+func (client *Client) ShoppingListCreate(ctx context.Context, draft *ShoppingListDraft, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ShoppingListURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ShoppingListQuery(ctx context.Context, input *QueryInput) 
 }
 
 // ShoppingListDeleteWithKey for type ShoppingList
-func (client *Client) ShoppingListDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool) (result *ShoppingList, err error) {
+func (client *Client) ShoppingListDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool, opts ...RequestOption) (result *ShoppingList, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("shopping-lists/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ShoppingListDeleteWithKey(ctx context.Context, key string,
 }
 
 // ShoppingListGetWithKey Gets a shopping list by Key.
-func (client *Client) ShoppingListGetWithKey(ctx context.Context, key string) (result *ShoppingList, err error) {
-	err = client.Get(ctx, strings.Replace("shopping-lists/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ShoppingListGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("shopping-lists/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ShoppingListUpdateWithKeyInput struct {
 }
 
 // ShoppingListUpdateWithKey Update a shopping list found by its Key.
-func (client *Client) ShoppingListUpdateWithKey(ctx context.Context, input *ShoppingListUpdateWithKeyInput) (result *ShoppingList, err error) {
-	err = client.Update(ctx, strings.Replace("shopping-lists/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShoppingListUpdateWithKey(ctx context.Context, input *ShoppingListUpdateWithKeyInput, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("shopping-lists/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ShoppingListUpdateWithKey(ctx context.Context, input *Shop
 }
 
 // ShoppingListDeleteWithID for type ShoppingList
-func (client *Client) ShoppingListDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool) (result *ShoppingList, err error) {
+func (client *Client) ShoppingListDeleteWithID(ctx context.Context, ID string, version int, dataErasure bool, opts ...RequestOption) (result *ShoppingList, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ShoppingListDeleteWithID(ctx context.Context, ID string, v
 }
 
 // ShoppingListGetWithID Gets a shopping list by ID.
-func (client *Client) ShoppingListGetWithID(ctx context.Context, ID string) (result *ShoppingList, err error) {
-	err = client.Get(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ShoppingListGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ShoppingListUpdateWithIDInput struct {
 }
 
 // ShoppingListUpdateWithID for type ShoppingList
-func (client *Client) ShoppingListUpdateWithID(ctx context.Context, input *ShoppingListUpdateWithIDInput) (result *ShoppingList, err error) {
-	err = client.Update(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ShoppingListUpdateWithID(ctx context.Context, input *ShoppingListUpdateWithIDInput, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("shopping-lists/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_state.go
+++ b/commercetools/service_state.go
@@ -13,8 +13,12 @@ import (
 const StateURLPath = "states"
 
 // StateCreate creates a new instance of type State
-func (client *Client) StateCreate(ctx context.Context, draft *StateDraft) (result *State, err error) {
-	err = client.Create(ctx, StateURLPath, nil, draft, &result)
+func (client *Client) StateCreate(ctx context.Context, draft *StateDraft, opts ...RequestOption) (result *State, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, StateURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) StateQuery(ctx context.Context, input *QueryInput) (result
 }
 
 // StateDeleteWithID for type State
-func (client *Client) StateDeleteWithID(ctx context.Context, ID string, version int) (result *State, err error) {
+func (client *Client) StateDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *State, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("states/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) StateDeleteWithID(ctx context.Context, ID string, version 
 }
 
 // StateGetWithID for type State
-func (client *Client) StateGetWithID(ctx context.Context, ID string) (result *State, err error) {
-	err = client.Get(ctx, strings.Replace("states/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) StateGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *State, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("states/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type StateUpdateWithIDInput struct {
 }
 
 // StateUpdateWithID for type State
-func (client *Client) StateUpdateWithID(ctx context.Context, input *StateUpdateWithIDInput) (result *State, err error) {
-	err = client.Update(ctx, strings.Replace("states/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StateUpdateWithID(ctx context.Context, input *StateUpdateWithIDInput, opts ...RequestOption) (result *State, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("states/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_store.go
+++ b/commercetools/service_store.go
@@ -13,8 +13,12 @@ import (
 const StoreURLPath = "stores"
 
 // StoreCreate creates a new instance of type Store
-func (client *Client) StoreCreate(ctx context.Context, draft *StoreDraft) (result *Store, err error) {
-	err = client.Create(ctx, StoreURLPath, nil, draft, &result)
+func (client *Client) StoreCreate(ctx context.Context, draft *StoreDraft, opts ...RequestOption) (result *Store, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, StoreURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) StoreQuery(ctx context.Context, input *QueryInput) (result
 }
 
 // StoreDeleteWithKey for type Store
-func (client *Client) StoreDeleteWithKey(ctx context.Context, key string, version int) (result *Store, err error) {
+func (client *Client) StoreDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Store, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("stores/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) StoreDeleteWithKey(ctx context.Context, key string, versio
 }
 
 // StoreGetWithKey for type Store
-func (client *Client) StoreGetWithKey(ctx context.Context, key string) (result *Store, err error) {
-	err = client.Get(ctx, strings.Replace("stores/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) StoreGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Store, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("stores/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type StoreUpdateWithKeyInput struct {
 }
 
 // StoreUpdateWithKey for type Store
-func (client *Client) StoreUpdateWithKey(ctx context.Context, input *StoreUpdateWithKeyInput) (result *Store, err error) {
-	err = client.Update(ctx, strings.Replace("stores/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StoreUpdateWithKey(ctx context.Context, input *StoreUpdateWithKeyInput, opts ...RequestOption) (result *Store, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("stores/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) StoreUpdateWithKey(ctx context.Context, input *StoreUpdate
 }
 
 // StoreDeleteWithID for type Store
-func (client *Client) StoreDeleteWithID(ctx context.Context, ID string, version int) (result *Store, err error) {
+func (client *Client) StoreDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Store, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("stores/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) StoreDeleteWithID(ctx context.Context, ID string, version 
 }
 
 // StoreGetWithID for type Store
-func (client *Client) StoreGetWithID(ctx context.Context, ID string) (result *Store, err error) {
-	err = client.Get(ctx, strings.Replace("stores/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) StoreGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Store, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("stores/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type StoreUpdateWithIDInput struct {
 }
 
 // StoreUpdateWithID for type Store
-func (client *Client) StoreUpdateWithID(ctx context.Context, input *StoreUpdateWithIDInput) (result *Store, err error) {
-	err = client.Update(ctx, strings.Replace("stores/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) StoreUpdateWithID(ctx context.Context, input *StoreUpdateWithIDInput, opts ...RequestOption) (result *Store, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("stores/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_subscription.go
+++ b/commercetools/service_subscription.go
@@ -13,8 +13,12 @@ import (
 const SubscriptionURLPath = "subscriptions"
 
 // SubscriptionCreate creates a new instance of type Subscription
-func (client *Client) SubscriptionCreate(ctx context.Context, draft *SubscriptionDraft) (result *Subscription, err error) {
-	err = client.Create(ctx, SubscriptionURLPath, nil, draft, &result)
+func (client *Client) SubscriptionCreate(ctx context.Context, draft *SubscriptionDraft, opts ...RequestOption) (result *Subscription, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, SubscriptionURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) SubscriptionQuery(ctx context.Context, input *QueryInput) 
 }
 
 // SubscriptionDeleteWithKey for type Subscription
-func (client *Client) SubscriptionDeleteWithKey(ctx context.Context, key string, version int) (result *Subscription, err error) {
+func (client *Client) SubscriptionDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Subscription, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("subscriptions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) SubscriptionDeleteWithKey(ctx context.Context, key string,
 }
 
 // SubscriptionGetWithKey Retrieves the representation of a subscription by its key.
-func (client *Client) SubscriptionGetWithKey(ctx context.Context, key string) (result *Subscription, err error) {
-	err = client.Get(ctx, strings.Replace("subscriptions/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) SubscriptionGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Subscription, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("subscriptions/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type SubscriptionUpdateWithKeyInput struct {
 }
 
 // SubscriptionUpdateWithKey for type Subscription
-func (client *Client) SubscriptionUpdateWithKey(ctx context.Context, input *SubscriptionUpdateWithKeyInput) (result *Subscription, err error) {
-	err = client.Update(ctx, strings.Replace("subscriptions/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) SubscriptionUpdateWithKey(ctx context.Context, input *SubscriptionUpdateWithKeyInput, opts ...RequestOption) (result *Subscription, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("subscriptions/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) SubscriptionUpdateWithKey(ctx context.Context, input *Subs
 }
 
 // SubscriptionDeleteWithID for type Subscription
-func (client *Client) SubscriptionDeleteWithID(ctx context.Context, ID string, version int) (result *Subscription, err error) {
+func (client *Client) SubscriptionDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Subscription, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) SubscriptionDeleteWithID(ctx context.Context, ID string, v
 }
 
 // SubscriptionGetWithID Retrieves the representation of a subscription by its id.
-func (client *Client) SubscriptionGetWithID(ctx context.Context, ID string) (result *Subscription, err error) {
-	err = client.Get(ctx, strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) SubscriptionGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Subscription, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("subscriptions/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type SubscriptionUpdateWithIDInput struct {
 }
 
 // SubscriptionUpdateWithID for type Subscription
-func (client *Client) SubscriptionUpdateWithID(ctx context.Context, input *SubscriptionUpdateWithIDInput) (result *Subscription, err error) {
-	err = client.Update(ctx, strings.Replace("subscriptions/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) SubscriptionUpdateWithID(ctx context.Context, input *SubscriptionUpdateWithIDInput, opts ...RequestOption) (result *Subscription, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("subscriptions/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_tax_category.go
+++ b/commercetools/service_tax_category.go
@@ -13,8 +13,12 @@ import (
 const TaxCategoryURLPath = "tax-categories"
 
 // TaxCategoryCreate creates a new instance of type TaxCategory
-func (client *Client) TaxCategoryCreate(ctx context.Context, draft *TaxCategoryDraft) (result *TaxCategory, err error) {
-	err = client.Create(ctx, TaxCategoryURLPath, nil, draft, &result)
+func (client *Client) TaxCategoryCreate(ctx context.Context, draft *TaxCategoryDraft, opts ...RequestOption) (result *TaxCategory, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, TaxCategoryURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) TaxCategoryQuery(ctx context.Context, input *QueryInput) (
 }
 
 // TaxCategoryDeleteWithKey for type TaxCategory
-func (client *Client) TaxCategoryDeleteWithKey(ctx context.Context, key string, version int) (result *TaxCategory, err error) {
+func (client *Client) TaxCategoryDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *TaxCategory, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("tax-categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) TaxCategoryDeleteWithKey(ctx context.Context, key string, 
 }
 
 // TaxCategoryGetWithKey for type TaxCategory
-func (client *Client) TaxCategoryGetWithKey(ctx context.Context, key string) (result *TaxCategory, err error) {
-	err = client.Get(ctx, strings.Replace("tax-categories/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) TaxCategoryGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *TaxCategory, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("tax-categories/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type TaxCategoryUpdateWithKeyInput struct {
 }
 
 // TaxCategoryUpdateWithKey for type TaxCategory
-func (client *Client) TaxCategoryUpdateWithKey(ctx context.Context, input *TaxCategoryUpdateWithKeyInput) (result *TaxCategory, err error) {
-	err = client.Update(ctx, strings.Replace("tax-categories/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TaxCategoryUpdateWithKey(ctx context.Context, input *TaxCategoryUpdateWithKeyInput, opts ...RequestOption) (result *TaxCategory, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("tax-categories/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) TaxCategoryUpdateWithKey(ctx context.Context, input *TaxCa
 }
 
 // TaxCategoryDeleteWithID for type TaxCategory
-func (client *Client) TaxCategoryDeleteWithID(ctx context.Context, ID string, version int) (result *TaxCategory, err error) {
+func (client *Client) TaxCategoryDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *TaxCategory, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) TaxCategoryDeleteWithID(ctx context.Context, ID string, ve
 }
 
 // TaxCategoryGetWithID for type TaxCategory
-func (client *Client) TaxCategoryGetWithID(ctx context.Context, ID string) (result *TaxCategory, err error) {
-	err = client.Get(ctx, strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) TaxCategoryGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *TaxCategory, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("tax-categories/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type TaxCategoryUpdateWithIDInput struct {
 }
 
 // TaxCategoryUpdateWithID for type TaxCategory
-func (client *Client) TaxCategoryUpdateWithID(ctx context.Context, input *TaxCategoryUpdateWithIDInput) (result *TaxCategory, err error) {
-	err = client.Update(ctx, strings.Replace("tax-categories/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TaxCategoryUpdateWithID(ctx context.Context, input *TaxCategoryUpdateWithIDInput, opts ...RequestOption) (result *TaxCategory, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("tax-categories/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_type.go
+++ b/commercetools/service_type.go
@@ -13,8 +13,12 @@ import (
 const TypeURLPath = "types"
 
 // TypeCreate creates a new instance of type Type
-func (client *Client) TypeCreate(ctx context.Context, draft *TypeDraft) (result *Type, err error) {
-	err = client.Create(ctx, TypeURLPath, nil, draft, &result)
+func (client *Client) TypeCreate(ctx context.Context, draft *TypeDraft, opts ...RequestOption) (result *Type, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, TypeURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) TypeQuery(ctx context.Context, input *QueryInput) (result 
 }
 
 // TypeDeleteWithKey for type Type
-func (client *Client) TypeDeleteWithKey(ctx context.Context, key string, version int) (result *Type, err error) {
+func (client *Client) TypeDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Type, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) TypeDeleteWithKey(ctx context.Context, key string, version
 }
 
 // TypeGetWithKey for type Type
-func (client *Client) TypeGetWithKey(ctx context.Context, key string) (result *Type, err error) {
-	err = client.Get(ctx, strings.Replace("types/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) TypeGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Type, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("types/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type TypeUpdateWithKeyInput struct {
 }
 
 // TypeUpdateWithKey for type Type
-func (client *Client) TypeUpdateWithKey(ctx context.Context, input *TypeUpdateWithKeyInput) (result *Type, err error) {
-	err = client.Update(ctx, strings.Replace("types/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TypeUpdateWithKey(ctx context.Context, input *TypeUpdateWithKeyInput, opts ...RequestOption) (result *Type, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("types/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) TypeUpdateWithKey(ctx context.Context, input *TypeUpdateWi
 }
 
 // TypeDeleteWithID for type Type
-func (client *Client) TypeDeleteWithID(ctx context.Context, ID string, version int) (result *Type, err error) {
+func (client *Client) TypeDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Type, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) TypeDeleteWithID(ctx context.Context, ID string, version i
 }
 
 // TypeGetWithID for type Type
-func (client *Client) TypeGetWithID(ctx context.Context, ID string) (result *Type, err error) {
-	err = client.Get(ctx, strings.Replace("types/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) TypeGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Type, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("types/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type TypeUpdateWithIDInput struct {
 }
 
 // TypeUpdateWithID for type Type
-func (client *Client) TypeUpdateWithID(ctx context.Context, input *TypeUpdateWithIDInput) (result *Type, err error) {
-	err = client.Update(ctx, strings.Replace("types/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) TypeUpdateWithID(ctx context.Context, input *TypeUpdateWithIDInput, opts ...RequestOption) (result *Type, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("types/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/commercetools/service_zone.go
+++ b/commercetools/service_zone.go
@@ -13,8 +13,12 @@ import (
 const ZoneURLPath = "zones"
 
 // ZoneCreate creates a new instance of type Zone
-func (client *Client) ZoneCreate(ctx context.Context, draft *ZoneDraft) (result *Zone, err error) {
-	err = client.Create(ctx, ZoneURLPath, nil, draft, &result)
+func (client *Client) ZoneCreate(ctx context.Context, draft *ZoneDraft, opts ...RequestOption) (result *Zone, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Create(ctx, ZoneURLPath, params, draft, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -31,10 +35,13 @@ func (client *Client) ZoneQuery(ctx context.Context, input *QueryInput) (result 
 }
 
 // ZoneDeleteWithKey for type Zone
-func (client *Client) ZoneDeleteWithKey(ctx context.Context, key string, version int) (result *Zone, err error) {
+func (client *Client) ZoneDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *Zone, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("zones/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -43,8 +50,12 @@ func (client *Client) ZoneDeleteWithKey(ctx context.Context, key string, version
 }
 
 // ZoneGetWithKey for type Zone
-func (client *Client) ZoneGetWithKey(ctx context.Context, key string) (result *Zone, err error) {
-	err = client.Get(ctx, strings.Replace("zones/key={key}", "{key}", key, 1), nil, &result)
+func (client *Client) ZoneGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Zone, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("zones/key={key}", "{key}", key, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +70,12 @@ type ZoneUpdateWithKeyInput struct {
 }
 
 // ZoneUpdateWithKey for type Zone
-func (client *Client) ZoneUpdateWithKey(ctx context.Context, input *ZoneUpdateWithKeyInput) (result *Zone, err error) {
-	err = client.Update(ctx, strings.Replace("zones/key={key}", "{key}", input.Key, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ZoneUpdateWithKey(ctx context.Context, input *ZoneUpdateWithKeyInput, opts ...RequestOption) (result *Zone, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("zones/key={key}", "{key}", input.Key, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +83,13 @@ func (client *Client) ZoneUpdateWithKey(ctx context.Context, input *ZoneUpdateWi
 }
 
 // ZoneDeleteWithID for type Zone
-func (client *Client) ZoneDeleteWithID(ctx context.Context, ID string, version int) (result *Zone, err error) {
+func (client *Client) ZoneDeleteWithID(ctx context.Context, ID string, version int, opts ...RequestOption) (result *Zone, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
+	for _, opt := range opts {
+		opt(&params)
+	}
 	err = client.Delete(ctx, strings.Replace("zones/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
@@ -80,8 +98,12 @@ func (client *Client) ZoneDeleteWithID(ctx context.Context, ID string, version i
 }
 
 // ZoneGetWithID for type Zone
-func (client *Client) ZoneGetWithID(ctx context.Context, ID string) (result *Zone, err error) {
-	err = client.Get(ctx, strings.Replace("zones/{ID}", "{ID}", ID, 1), nil, &result)
+func (client *Client) ZoneGetWithID(ctx context.Context, ID string, opts ...RequestOption) (result *Zone, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Get(ctx, strings.Replace("zones/{ID}", "{ID}", ID, 1), params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +118,12 @@ type ZoneUpdateWithIDInput struct {
 }
 
 // ZoneUpdateWithID for type Zone
-func (client *Client) ZoneUpdateWithID(ctx context.Context, input *ZoneUpdateWithIDInput) (result *Zone, err error) {
-	err = client.Update(ctx, strings.Replace("zones/{ID}", "{ID}", input.ID, 1), nil, input.Version, input.Actions, &result)
+func (client *Client) ZoneUpdateWithID(ctx context.Context, input *ZoneUpdateWithIDInput, opts ...RequestOption) (result *Zone, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	err = client.Update(ctx, strings.Replace("zones/{ID}", "{ID}", input.ID, 1), params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is done via functional options e.g.

```go 
client.ProductCreate(
	ctx,
	productDraft,
	commercetools.WithReferenceExpansion("productType", "taxCategory"))
```