### PR TITLE
Correctly implement date handling

### DIFF
--- a/code-generate/generate_types.go
+++ b/code-generate/generate_types.go
@@ -402,7 +402,7 @@ func generateStructField(object RamlTypeAttribute) jen.Code {
 			}
 			code = code.Qual("time", "Time")
 		case "date-only":
-			code = code.Id("Date")
+			code = code.Op("*").Id("Date")
 		default:
 			code = code.Interface()
 		}

--- a/commercetools/date.go
+++ b/commercetools/date.go
@@ -3,6 +3,7 @@ package commercetools
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -21,7 +22,7 @@ func NewDate(year int, month time.Month, day int) Date {
 // MarshalJSON marshals into the commercetools date format
 func (d *Date) MarshalJSON() ([]byte, error) {
 	value := fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day)
-	return []byte(value), nil
+	return []byte(strconv.Quote(value)), nil
 }
 
 // UnmarshalJSON decodes JSON data into a Date struct

--- a/commercetools/date_test.go
+++ b/commercetools/date_test.go
@@ -1,0 +1,59 @@
+package commercetools_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateSerialization(t *testing.T) {
+
+	data := struct {
+		String   string              `json:"string"`
+		Value    *commercetools.Date `json:"value"`
+		Optional *commercetools.Date `json:"optional",omitempty`
+	}{}
+	data.String = "foobar"
+	data.Value = &commercetools.Date{Year: 1983, Month: 5, Day: 10}
+	data.Optional = &commercetools.Date{Year: 1983, Month: 5, Day: 10}
+
+	m, err := json.Marshal(data)
+	assert.NoError(t, err)
+
+	expected := `{"string":"foobar","value":"1983-05-10","optional":"1983-05-10"}`
+	assert.Equal(t, expected, string(m))
+}
+
+func TestDateSerializationEmpty(t *testing.T) {
+
+	data := struct {
+		String   string              `json:"string"`
+		Value    *commercetools.Date `json:"value"`
+		Optional *commercetools.Date `json:"optional,omitempty"`
+	}{}
+	data.String = "foobar"
+
+	m, err := json.Marshal(data)
+	assert.NoError(t, err)
+
+	expected := `{"string":"foobar","value":null}`
+	assert.Equal(t, expected, string(m))
+}
+
+func TestDateDeserialization(t *testing.T) {
+
+	data := struct {
+		String   string              `json:"string"`
+		Value    *commercetools.Date `json:"value"`
+		Optional *commercetools.Date `json:"optional",omitempty`
+	}{}
+
+	value := `{"string":"foobar","value":"1983-05-10"}`
+	err := json.Unmarshal([]byte(value), &data)
+	assert.NoError(t, err)
+	assert.Equal(t, "foobar", data.String)
+	assert.Equal(t, &commercetools.Date{Year: 1983, Month: 5, Day: 10}, data.Value)
+	assert.Equal(t, (*commercetools.Date)(nil), data.Optional)
+}

--- a/commercetools/service_api_client_test.go
+++ b/commercetools/service_api_client_test.go
@@ -59,7 +59,7 @@ func TestAPIClientGetByID(t *testing.T) {
 		Scope:      "view_products",
 		Name:       "api-client-name",
 		CreatedAt:  &timestamp,
-		LastUsedAt: commercetools.NewDate(2017, 9, 10),
+		LastUsedAt: &commercetools.Date{Year: 2017, Month: 9, Day: 10},
 		Secret:     "secret-passphrase",
 	}
 

--- a/commercetools/types_api_client.go
+++ b/commercetools/types_api_client.go
@@ -9,7 +9,7 @@ type APIClient struct {
 	Secret     string     `json:"secret,omitempty"`
 	Scope      string     `json:"scope"`
 	Name       string     `json:"name"`
-	LastUsedAt Date       `json:"lastUsedAt,omitempty"`
+	LastUsedAt *Date      `json:"lastUsedAt,omitempty"`
 	ID         string     `json:"id"`
 	DeleteAt   *time.Time `json:"deleteAt,omitempty"`
 	CreatedAt  *time.Time `json:"createdAt,omitempty"`

--- a/commercetools/types_customer.go
+++ b/commercetools/types_customer.go
@@ -255,7 +255,7 @@ type Customer struct {
 	Email                    string                  `json:"email"`
 	DefaultShippingAddressID string                  `json:"defaultShippingAddressId,omitempty"`
 	DefaultBillingAddressID  string                  `json:"defaultBillingAddressId,omitempty"`
-	DateOfBirth              Date                    `json:"dateOfBirth,omitempty"`
+	DateOfBirth              *Date                   `json:"dateOfBirth,omitempty"`
 	CustomerNumber           string                  `json:"customerNumber,omitempty"`
 	CustomerGroup            *CustomerGroupReference `json:"customerGroup,omitempty"`
 	Custom                   *CustomFields           `json:"custom,omitempty"`
@@ -393,7 +393,7 @@ type CustomerDraft struct {
 	Email                  string                           `json:"email"`
 	DefaultShippingAddress int                              `json:"defaultShippingAddress,omitempty"`
 	DefaultBillingAddress  int                              `json:"defaultBillingAddress,omitempty"`
-	DateOfBirth            Date                             `json:"dateOfBirth,omitempty"`
+	DateOfBirth            *Date                            `json:"dateOfBirth,omitempty"`
 	CustomerNumber         string                           `json:"customerNumber,omitempty"`
 	CustomerGroup          *CustomerGroupResourceIdentifier `json:"customerGroup,omitempty"`
 	Custom                 *CustomFieldsDraft               `json:"custom,omitempty"`
@@ -589,7 +589,7 @@ func (obj CustomerSetCustomerNumberAction) MarshalJSON() ([]byte, error) {
 
 // CustomerSetDateOfBirthAction implements the interface CustomerUpdateAction
 type CustomerSetDateOfBirthAction struct {
-	DateOfBirth Date `json:"dateOfBirth,omitempty"`
+	DateOfBirth *Date `json:"dateOfBirth,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value

--- a/commercetools/types_me.go
+++ b/commercetools/types_me.go
@@ -1059,7 +1059,7 @@ type MyCustomer struct {
 	Email                    string                  `json:"email"`
 	DefaultShippingAddressID string                  `json:"defaultShippingAddressId,omitempty"`
 	DefaultBillingAddressID  string                  `json:"defaultBillingAddressId,omitempty"`
-	DateOfBirth              Date                    `json:"dateOfBirth,omitempty"`
+	DateOfBirth              *Date                   `json:"dateOfBirth,omitempty"`
 	CustomerNumber           string                  `json:"customerNumber,omitempty"`
 	CustomerGroup            *CustomerGroupReference `json:"customerGroup,omitempty"`
 	Custom                   *CustomFields           `json:"custom,omitempty"`
@@ -1154,7 +1154,7 @@ type MyCustomerDraft struct {
 	Email                  string                    `json:"email"`
 	DefaultShippingAddress int                       `json:"defaultShippingAddress,omitempty"`
 	DefaultBillingAddress  int                       `json:"defaultBillingAddress,omitempty"`
-	DateOfBirth            Date                      `json:"dateOfBirth,omitempty"`
+	DateOfBirth            *Date                     `json:"dateOfBirth,omitempty"`
 	Custom                 *CustomFields             `json:"custom,omitempty"`
 	CompanyName            string                    `json:"companyName,omitempty"`
 	Addresses              []Address                 `json:"addresses,omitempty"`
@@ -1248,7 +1248,7 @@ func (obj MyCustomerSetCustomTypeAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerSetDateOfBirthAction implements the interface MyCustomerUpdateAction
 type MyCustomerSetDateOfBirthAction struct {
-	DateOfBirth Date `json:"dateOfBirth,omitempty"`
+	DateOfBirth *Date `json:"dateOfBirth,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value

--- a/commercetools/types_message.go
+++ b/commercetools/types_message.go
@@ -1412,7 +1412,7 @@ type CustomerDateOfBirthSetMessage struct {
 	ID                              string                   `json:"id"`
 	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
 	CreatedAt                       time.Time                `json:"createdAt"`
-	DateOfBirth                     Date                     `json:"dateOfBirth"`
+	DateOfBirth                     *Date                    `json:"dateOfBirth"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1426,7 +1426,7 @@ func (obj CustomerDateOfBirthSetMessage) MarshalJSON() ([]byte, error) {
 
 // CustomerDateOfBirthSetMessagePayload implements the interface MessagePayload
 type CustomerDateOfBirthSetMessagePayload struct {
-	DateOfBirth Date `json:"dateOfBirth"`
+	DateOfBirth *Date `json:"dateOfBirth"`
 }
 
 // MarshalJSON override to set the discriminator value


### PR DESCRIPTION
Use a pointer for Date fields so that it can be properly empty. This is
for example required when creating a custom and their DateOfBirth field
should be left out of the request (omitempty).