### PR TITLE
fixing bug, empty response from CustomerCreate call

### DIFF
--- a/commercetools/service_customer.go
+++ b/commercetools/service_customer.go
@@ -11,7 +11,7 @@ import (
 
 // CustomerCreate creates a new instance of type Customer
 func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft, opts ...RequestOption) (result *Customer, err error) {
-	res := &CustomerCreatedResponse{}
+	res := &CustomerResponse{}
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)
@@ -82,7 +82,7 @@ func (client *Client) CustomerGetWithEmailToken(ctx context.Context, emailToken 
 }
 
 // CustomerGetWithID for type Customer
-func (client *Client) CustomerGetWithID(ctx context.Context, id string, opts ...RequestOption) (result *Customer, err error) {
+func (client *Client) CustomerGetWithID(ctx context.Context, id string, opts ...RequestOption) (result *CustomerResponse, err error) {
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)

--- a/commercetools/service_customer.go
+++ b/commercetools/service_customer.go
@@ -11,17 +11,18 @@ import (
 
 // CustomerCreate creates a new instance of type Customer
 func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft, opts ...RequestOption) (result *Customer, err error) {
+	res := &CustomerCreatedResponse{}
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)
 	}
 
 	endpoint := "customers"
-	err = client.create(ctx, endpoint, params, draft, &result)
+	err = client.create(ctx, endpoint, params, draft, res)
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return res.Customer, nil
 }
 
 // CustomerQuery allows querying for type Customer

--- a/commercetools/service_customer_generated_test.go
+++ b/commercetools/service_customer_generated_test.go
@@ -43,7 +43,7 @@ func TestGeneratedCustomerGetWithEmailToken(t *testing.T) {
 }
 
 func TestGeneratedCustomerGetWithID(t *testing.T) {
-	responseData := ` {
+	responseData := ` { "customer": {
 	      "addresses": [],
 	      "email": "<random>@example.com",
 	      "firstName": "John",
@@ -54,7 +54,7 @@ func TestGeneratedCustomerGetWithID(t *testing.T) {
 	      "version": 1,
 	      "createdAt": "2015-07-06T13:22:33.339Z",
 	      "lastModifiedAt": "2015-07-06T13:22:33.339Z"
-	} `
+	} }`
 	client, server := testutil.MockClient(t, responseData, nil, nil)
 	defer server.Close()
 	customer, err := client.CustomerGetWithID(context.TODO(), "dummy-id")
@@ -62,15 +62,15 @@ func TestGeneratedCustomerGetWithID(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.NotNil(t, customer)
-	assert.NotNil(t, customer.Version)
-	assert.NotEmpty(t, customer.Password)
-	assert.NotEmpty(t, customer.LastName)
-	assert.NotEmpty(t, customer.LastModifiedAt)
-	assert.False(t, customer.IsEmailVerified)
-	assert.NotEmpty(t, customer.ID)
-	assert.NotEmpty(t, customer.FirstName)
-	assert.NotEmpty(t, customer.Email)
-	assert.NotEmpty(t, customer.CreatedAt)
+	assert.NotNil(t, customer.Customer.Version)
+	assert.NotEmpty(t, customer.Customer.Password)
+	assert.NotEmpty(t, customer.Customer.LastName)
+	assert.NotEmpty(t, customer.Customer.LastModifiedAt)
+	assert.False(t, customer.Customer.IsEmailVerified)
+	assert.NotEmpty(t, customer.Customer.ID)
+	assert.NotEmpty(t, customer.Customer.FirstName)
+	assert.NotEmpty(t, customer.Customer.Email)
+	assert.NotEmpty(t, customer.Customer.CreatedAt)
 
 }
 

--- a/commercetools/types_customer.go
+++ b/commercetools/types_customer.go
@@ -801,7 +801,7 @@ type CustomerUpdate struct {
 	Actions []CustomerUpdateAction `json:"actions"`
 }
 
-type CustomerCreatedResponse struct {
+type CustomerResponse struct {
 	Customer *Customer   `json:"customer"`
 }
 

--- a/commercetools/types_customer.go
+++ b/commercetools/types_customer.go
@@ -801,6 +801,10 @@ type CustomerUpdate struct {
 	Actions []CustomerUpdateAction `json:"actions"`
 }
 
+type CustomerCreatedResponse struct {
+	Customer *Customer   `json:"customer"`
+}
+
 // UnmarshalJSON override to deserialize correct attribute types based
 // on the discriminator value
 func (obj *CustomerUpdate) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
the api response of createCustomer is

```
{
  "customer": {
    ......
}
```

deserializing the response to Customer object fails, ( silently )
because it expects the inner object. 
The wrapping of the response in "customer":{...} causes this.