### PR TITLE
Upgrade services and types from commercetools-api-reference@7184cde891c72d52e611cc6e91fcd29fc4caf78b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+0.3.0 (draft)
+=============
+ - Upgrade services and types from commercetools-api-reference@7184cde891c72d52e611cc6e91fcd29fc4caf78b (#59)
+
+## Breaking changes
+
+### Removed
+ - ExtensionNoResponseError.ErrorByExtension
+ - ExtensionNoResponseError.ExtensionExtraInfo
+ - ExtensionNoResponseError.LocalizedMessage
+ - PagedQueryResponse.Facets
+ - TaxedPriceDraft.UnmarshalJSON()
+
+## Renamed
+ - StoresAddDistributionChannelsAction renamed to StoreAddDistributionChannelAction
+ - StoresAddSupplyChannelsAction renamed to StoreAddSupplyChannelAction
+ - StoresRemoveDistributionChannelsAction renamed to StoreRemoveDistributionChannelAction
+ - StoresRemoveSupplyChannelsAction renamed to StoreRemoveSupplyChannelAction
+ - StoresSetDistributionChannelsAction renamed to StoreSetDistributionChannelsAction
+ - StoresSetSupplyChannelsAction renamed to StoreSetSupplyChannelsAction
+
+### Changes
+
+| struct                                                 | old type          | new type
+|--------------------------------------------------------|-------------------|------------------------
+| CartDiscount.Value                                     | CartDiscountValue | CartDiscountValueDraft
+| CartDiscountValueGiftLineItemDraft.DistributionChannel | *ChannelReference | *ChannelResourceIdentifier
+| CartDiscountValueGiftLineItemDraft.Product             | *ProductReference | *ProductResourceIdentifier
+| CartDiscountValueGiftLineItemDraft.SupplyChannel       | *ChannelReference | *ChannelResourceIdentifier
+| CartSetShippingMethodAction.Custom                     | *CustomFields     | *CustomFieldsDraft
+| CustomerSignInResult.Cart                              | interface{}       | *Cart
+| DeliveryAddedMessage.RemovedImageUrls                  | []interface{}     | []string
+| DeliveryItem.Quantity                                  | float64           | int
+| FacetResultRange.Total                                 | int               | float64
+| MyCartAddLineItemAction.Quantity                       | float64           | int
+| MyCartChangeLineItemQuantityAction.Quantity            | float64           | int
+| MyCartRemoveLineItemAction.Quantity                    | float64           | int
+| ProductPublishedMessagePayload.RemovedImageUrls        | []interface{}     | []string
+| TaxedPriceDraft.TotalNet                               | TypedMoneyDraft   | *Money
+| TaxedPriceDraft.TotalGross                             | TypedMoneyDraft   | *Money
+
 0.2.0 (2020-07-20)
 ==================
  - *Backwards incompatible:* Add context parameter to all method calls. (#51)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ coverage:
 	go tool cover -html=coverage.txt
 
 code-generate/prepared.raml:
-	python ./code-generate/prepare_yaml.py ../commercetools-api-reference/api.raml ./code-generate/prepared.raml
+	python ./code-generate/prepare_yaml.py ../commercetools-api-reference/api-specs/api/api.raml ./code-generate/prepared.raml
 
 generate: code-generate/prepared.raml
 	go run code-generate/*.go ./code-generate/prepared.raml

--- a/commercetools/service_cart.go
+++ b/commercetools/service_cart.go
@@ -50,6 +50,22 @@ func (client *Client) CartDeleteWithID(ctx context.Context, id string, version i
 	return result, nil
 }
 
+// CartDeleteWithKey for type Cart
+func (client *Client) CartDeleteWithKey(ctx context.Context, key string, version int, dataErasure bool, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	params.Set("version", strconv.Itoa(version))
+	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("carts/key=%s", key)
+	err = client.delete(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 /*
 CartGetWithCustomerID Retrieves the active cart of the customer that has been modified most recently.
 It does not consider carts with CartOrigin Merchant. If no active cart exists, a 404 Not Found error is returned.
@@ -87,6 +103,23 @@ func (client *Client) CartGetWithID(ctx context.Context, id string, opts ...Requ
 	return result, nil
 }
 
+/*
+CartGetWithKey The cart may not contain up-to-date prices, discounts etc.
+If you want to ensure they're up-to-date, send an Update request with the Recalculate update action instead.
+*/
+func (client *Client) CartGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("carts/key=%s", key)
+	err = client.get(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // CartUpdateWithIDInput is input for function CartUpdateWithID
 type CartUpdateWithIDInput struct {
 	ID      string
@@ -116,6 +149,42 @@ func (client *Client) CartUpdateWithID(ctx context.Context, input *CartUpdateWit
 	}
 
 	endpoint := fmt.Sprintf("carts/%s", input.ID)
+	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CartUpdateWithKeyInput is input for function CartUpdateWithKey
+type CartUpdateWithKeyInput struct {
+	Key     string
+	Version int
+	Actions []CartUpdateAction
+}
+
+func (input *CartUpdateWithKeyInput) Validate() error {
+	if input.Key == "" {
+		return fmt.Errorf("no valid value for Key given")
+	}
+	if len(input.Actions) == 0 {
+		return fmt.Errorf("no update actions specified")
+	}
+	return nil
+}
+
+// CartUpdateWithKey for type Cart
+func (client *Client) CartUpdateWithKey(ctx context.Context, input *CartUpdateWithKeyInput, opts ...RequestOption) (result *Cart, err error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("carts/key=%s", input.Key)
 	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err

--- a/commercetools/service_cart_generated_test.go
+++ b/commercetools/service_cart_generated_test.go
@@ -14,6 +14,7 @@ func TestGeneratedCartGetWithCustomerID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -121,6 +122,7 @@ func TestGeneratedCartGetWithCustomerID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -132,6 +134,7 @@ func TestGeneratedCartGetWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -239,6 +242,127 @@ func TestGeneratedCartGetWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
+	assert.NotEmpty(t, cart.InventoryMode)
+	assert.NotEmpty(t, cart.ID)
+	assert.NotEmpty(t, cart.CreatedAt)
+	assert.NotEmpty(t, cart.CartState)
+
+}
+
+func TestGeneratedCartGetWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	cart, err := client.CartGetWithKey(context.TODO(), "dummy-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, cart)
+	assert.NotNil(t, cart.Version)
+	assert.NotEmpty(t, cart.TaxRoundingMode)
+	assert.NotEmpty(t, cart.TaxMode)
+	assert.NotEmpty(t, cart.TaxCalculationMode)
+	assert.NotEmpty(t, cart.Origin)
+	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -250,6 +374,7 @@ func TestGeneratedCartDeleteWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -357,6 +482,127 @@ func TestGeneratedCartDeleteWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
+	assert.NotEmpty(t, cart.InventoryMode)
+	assert.NotEmpty(t, cart.ID)
+	assert.NotEmpty(t, cart.CreatedAt)
+	assert.NotEmpty(t, cart.CartState)
+
+}
+
+func TestGeneratedCartDeleteWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	cart, err := client.CartDeleteWithKey(context.TODO(), "dummy-id", 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, cart)
+	assert.NotNil(t, cart.Version)
+	assert.NotEmpty(t, cart.TaxRoundingMode)
+	assert.NotEmpty(t, cart.TaxMode)
+	assert.NotEmpty(t, cart.TaxCalculationMode)
+	assert.NotEmpty(t, cart.Origin)
+	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)

--- a/commercetools/service_in_store.go
+++ b/commercetools/service_in_store.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 )
 
-// StoreLogin Authenticate Customer (Sign In)
+// StoreLogin Authenticate Customer (Sign In) in store
 func (client *Client) StoreLogin(ctx context.Context, storeKey string, value *CustomerSignin, opts ...RequestOption) (result *CustomerSignInResult, err error) {
 	params := url.Values{}
 	for _, opt := range opts {
@@ -86,6 +86,22 @@ func (client *Client) StoreCartDeleteWithID(ctx context.Context, storeKey string
 	return result, nil
 }
 
+// StoreCartDeleteWithKey for type Cart
+func (client *Client) StoreCartDeleteWithKey(ctx context.Context, storeKey string, key string, version int, dataErasure bool, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	params.Set("version", strconv.Itoa(version))
+	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/carts/key=%s", storeKey, key)
+	err = client.delete(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 /*
 StoreCartGetWithCustomerID Retrieves the active cart of the customer that has been modified most recently in a specific Store.
 The {storeKey} path parameter maps to a Store's key.
@@ -129,6 +145,26 @@ func (client *Client) StoreCartGetWithID(ctx context.Context, storeKey string, i
 	return result, nil
 }
 
+/*
+StoreCartGetWithKey Returns a cart by its key from a specific Store. The {storeKey} path parameter maps to a Store's key.
+If the cart exists in the commercetools project but does not have the store field,
+or the store field references a different store, this method returns a ResourceNotFound error.
+The cart may not contain up-to-date prices, discounts etc.
+If you want to ensure they're up-to-date, send an Update request with the Recalculate update action instead.
+*/
+func (client *Client) StoreCartGetWithKey(ctx context.Context, storeKey string, key string, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/carts/key=%s", storeKey, key)
+	err = client.get(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // StoreCartUpdateWithIDInput is input for function StoreCartUpdateWithID
 type StoreCartUpdateWithIDInput struct {
 	ID      string
@@ -159,6 +195,57 @@ func (client *Client) StoreCartUpdateWithID(ctx context.Context, storeKey string
 
 	endpoint := fmt.Sprintf("in-store/key=%s/carts/%s", storeKey, input.ID)
 	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreCartUpdateWithKeyInput is input for function StoreCartUpdateWithKey
+type StoreCartUpdateWithKeyInput struct {
+	Key     string
+	Version int
+	Actions []CartUpdateAction
+}
+
+func (input *StoreCartUpdateWithKeyInput) Validate() error {
+	if input.Key == "" {
+		return fmt.Errorf("no valid value for Key given")
+	}
+	if len(input.Actions) == 0 {
+		return fmt.Errorf("no update actions specified")
+	}
+	return nil
+}
+
+// StoreCartUpdateWithKey for type Cart
+func (client *Client) StoreCartUpdateWithKey(ctx context.Context, storeKey string, input *StoreCartUpdateWithKeyInput, opts ...RequestOption) (result *Cart, err error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("in-store/key=%s/carts/key=%s", storeKey, input.Key)
+	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreCartReplicate for type ReplicaCartDraft
+func (client *Client) StoreCartReplicate(ctx context.Context, storeKey string, value *ReplicaCartDraft, opts ...RequestOption) (result *Cart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("in-store/key=%s/carts/replicate", storeKey)
+	err = client.create(ctx, endpoint, params, value, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -753,6 +840,163 @@ func (client *Client) StoreOrderUpdateWithOrderNumber(ctx context.Context, store
 	}
 
 	endpoint := fmt.Sprintf("in-store/key=%s/orders/order-number=%s", storeKey, input.OrderNumber)
+	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListCreate creates a new instance of type ShoppingList
+func (client *Client) StoreShoppingListCreate(ctx context.Context, storeKey string, draft *ShoppingListDraft, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists", storeKey)
+	err = client.create(ctx, endpoint, params, draft, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListQuery allows querying for type
+func (client *Client) StoreShoppingListQuery(ctx context.Context, storeKey string, input *QueryInput) (result *ShoppingListPagedQueryResponse, err error) {
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists", storeKey)
+	err = client.query(ctx, endpoint, input.toParams(), &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListDeleteWithID for type ShoppingList
+func (client *Client) StoreShoppingListDeleteWithID(ctx context.Context, storeKey string, id string, version int, dataErasure bool, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	params.Set("version", strconv.Itoa(version))
+	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/%s", storeKey, id)
+	err = client.delete(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListDeleteWithKey for type ShoppingList
+func (client *Client) StoreShoppingListDeleteWithKey(ctx context.Context, storeKey string, key string, version int, dataErasure bool, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	params.Set("version", strconv.Itoa(version))
+	params.Set("dataErasure", strconv.FormatBool(dataErasure))
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/key=%s", storeKey, key)
+	err = client.delete(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListGetWithID Gets a shopping list by ID.
+func (client *Client) StoreShoppingListGetWithID(ctx context.Context, storeKey string, id string, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/%s", storeKey, id)
+	err = client.get(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListGetWithKey Gets a shopping list by Key.
+func (client *Client) StoreShoppingListGetWithKey(ctx context.Context, storeKey string, key string, opts ...RequestOption) (result *ShoppingList, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/key=%s", storeKey, key)
+	err = client.get(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListUpdateWithIDInput is input for function StoreShoppingListUpdateWithID
+type StoreShoppingListUpdateWithIDInput struct {
+	ID      string
+	Version int
+	Actions []ShoppingListUpdateAction
+}
+
+func (input *StoreShoppingListUpdateWithIDInput) Validate() error {
+	if input.ID == "" {
+		return fmt.Errorf("no valid value for ID given")
+	}
+	if len(input.Actions) == 0 {
+		return fmt.Errorf("no update actions specified")
+	}
+	return nil
+}
+
+// StoreShoppingListUpdateWithID for type ShoppingList
+func (client *Client) StoreShoppingListUpdateWithID(ctx context.Context, storeKey string, input *StoreShoppingListUpdateWithIDInput, opts ...RequestOption) (result *ShoppingList, err error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/%s", storeKey, input.ID)
+	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StoreShoppingListUpdateWithKeyInput is input for function StoreShoppingListUpdateWithKey
+type StoreShoppingListUpdateWithKeyInput struct {
+	Key     string
+	Version int
+	Actions []ShoppingListUpdateAction
+}
+
+func (input *StoreShoppingListUpdateWithKeyInput) Validate() error {
+	if input.Key == "" {
+		return fmt.Errorf("no valid value for Key given")
+	}
+	if len(input.Actions) == 0 {
+		return fmt.Errorf("no update actions specified")
+	}
+	return nil
+}
+
+// StoreShoppingListUpdateWithKey for type ShoppingList
+func (client *Client) StoreShoppingListUpdateWithKey(ctx context.Context, storeKey string, input *StoreShoppingListUpdateWithKeyInput, opts ...RequestOption) (result *ShoppingList, err error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("in-store/key=%s/shopping-lists/key=%s", storeKey, input.Key)
 	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err

--- a/commercetools/service_in_store_generated_test.go
+++ b/commercetools/service_in_store_generated_test.go
@@ -14,6 +14,7 @@ func TestGeneratedStoreCartGetWithCustomerID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -121,6 +122,7 @@ func TestGeneratedStoreCartGetWithCustomerID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -132,6 +134,7 @@ func TestGeneratedStoreCartGetWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -239,6 +242,127 @@ func TestGeneratedStoreCartGetWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
+	assert.NotEmpty(t, cart.InventoryMode)
+	assert.NotEmpty(t, cart.ID)
+	assert.NotEmpty(t, cart.CreatedAt)
+	assert.NotEmpty(t, cart.CartState)
+
+}
+
+func TestGeneratedStoreCartGetWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	cart, err := client.StoreCartGetWithKey(context.TODO(), "dummy-id", "dummy-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, cart)
+	assert.NotNil(t, cart.Version)
+	assert.NotEmpty(t, cart.TaxRoundingMode)
+	assert.NotEmpty(t, cart.TaxMode)
+	assert.NotEmpty(t, cart.TaxCalculationMode)
+	assert.NotEmpty(t, cart.Origin)
+	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -250,6 +374,7 @@ func TestGeneratedStoreCartDeleteWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -357,6 +482,127 @@ func TestGeneratedStoreCartDeleteWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
+	assert.NotEmpty(t, cart.InventoryMode)
+	assert.NotEmpty(t, cart.ID)
+	assert.NotEmpty(t, cart.CreatedAt)
+	assert.NotEmpty(t, cart.CartState)
+
+}
+
+func TestGeneratedStoreCartDeleteWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	cart, err := client.StoreCartDeleteWithKey(context.TODO(), "dummy-id", "dummy-id", 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, cart)
+	assert.NotNil(t, cart.Version)
+	assert.NotEmpty(t, cart.TaxRoundingMode)
+	assert.NotEmpty(t, cart.TaxMode)
+	assert.NotEmpty(t, cart.TaxCalculationMode)
+	assert.NotEmpty(t, cart.Origin)
+	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -815,6 +1061,7 @@ func TestGeneratedStoreMyCartGetWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -922,6 +1169,7 @@ func TestGeneratedStoreMyCartGetWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -933,6 +1181,7 @@ func TestGeneratedStoreMyCartDeleteWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -1040,6 +1289,7 @@ func TestGeneratedStoreMyCartDeleteWithID(t *testing.T) {
 	assert.NotEmpty(t, cart.TaxCalculationMode)
 	assert.NotEmpty(t, cart.Origin)
 	assert.NotEmpty(t, cart.LastModifiedAt)
+	assert.NotEmpty(t, cart.Key)
 	assert.NotEmpty(t, cart.InventoryMode)
 	assert.NotEmpty(t, cart.ID)
 	assert.NotEmpty(t, cart.CreatedAt)
@@ -2257,6 +2507,154 @@ func TestGeneratedStoreOrderQuery(t *testing.T) {
 	defer server.Close()
 	input := commercetools.QueryInput{}
 	queryResult, err := client.StoreOrderQuery(context.TODO(), "dummy-id", &input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, queryResult)
+	assert.NotNil(t, queryResult.Total)
+	assert.NotNil(t, queryResult.Offset)
+	assert.NotNil(t, queryResult.Limit)
+	assert.NotNil(t, queryResult.Count)
+
+}
+
+func TestGeneratedStoreShoppingListGetWithID(t *testing.T) {
+	responseData := ` {
+	  "id": "9693f04b-5aec-467f-baa1-fc74da7d0c3d",
+	  "version": 1,
+	  "name": {
+	    "en": "test"
+	  },
+	  "key": "test",
+	  "lineItems": [],
+	  "textLineItems": [],
+	  "createdAt": "2017-03-30T11:49:40.904Z",
+	  "lastModifiedAt": "2017-03-30T11:49:40.904Z"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	shopping_list, err := client.StoreShoppingListGetWithID(context.TODO(), "dummy-id", "dummy-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, shopping_list)
+	assert.NotNil(t, shopping_list.Version)
+	assert.NotEmpty(t, shopping_list.LastModifiedAt)
+	assert.NotEmpty(t, shopping_list.Key)
+	assert.NotEmpty(t, shopping_list.ID)
+	assert.NotEmpty(t, shopping_list.CreatedAt)
+
+}
+
+func TestGeneratedStoreShoppingListGetWithKey(t *testing.T) {
+	responseData := ` {
+	  "id": "9693f04b-5aec-467f-baa1-fc74da7d0c3d",
+	  "version": 1,
+	  "name": {
+	    "en": "test"
+	  },
+	  "key": "test",
+	  "lineItems": [],
+	  "textLineItems": [],
+	  "createdAt": "2017-03-30T11:49:40.904Z",
+	  "lastModifiedAt": "2017-03-30T11:49:40.904Z"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	shopping_list, err := client.StoreShoppingListGetWithKey(context.TODO(), "dummy-id", "dummy-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, shopping_list)
+	assert.NotNil(t, shopping_list.Version)
+	assert.NotEmpty(t, shopping_list.LastModifiedAt)
+	assert.NotEmpty(t, shopping_list.Key)
+	assert.NotEmpty(t, shopping_list.ID)
+	assert.NotEmpty(t, shopping_list.CreatedAt)
+
+}
+
+func TestGeneratedStoreShoppingListDeleteWithID(t *testing.T) {
+	responseData := ` {
+	  "id": "9693f04b-5aec-467f-baa1-fc74da7d0c3d",
+	  "version": 1,
+	  "name": {
+	    "en": "test"
+	  },
+	  "key": "test",
+	  "lineItems": [],
+	  "textLineItems": [],
+	  "createdAt": "2017-03-30T11:49:40.904Z",
+	  "lastModifiedAt": "2017-03-30T11:49:40.904Z"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	shopping_list, err := client.StoreShoppingListDeleteWithID(context.TODO(), "dummy-id", "dummy-id", 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, shopping_list)
+	assert.NotNil(t, shopping_list.Version)
+	assert.NotEmpty(t, shopping_list.LastModifiedAt)
+	assert.NotEmpty(t, shopping_list.Key)
+	assert.NotEmpty(t, shopping_list.ID)
+	assert.NotEmpty(t, shopping_list.CreatedAt)
+
+}
+
+func TestGeneratedStoreShoppingListDeleteWithKey(t *testing.T) {
+	responseData := ` {
+	  "id": "9693f04b-5aec-467f-baa1-fc74da7d0c3d",
+	  "version": 1,
+	  "name": {
+	    "en": "test"
+	  },
+	  "key": "test",
+	  "lineItems": [],
+	  "textLineItems": [],
+	  "createdAt": "2017-03-30T11:49:40.904Z",
+	  "lastModifiedAt": "2017-03-30T11:49:40.904Z"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	shopping_list, err := client.StoreShoppingListDeleteWithKey(context.TODO(), "dummy-id", "dummy-id", 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, shopping_list)
+	assert.NotNil(t, shopping_list.Version)
+	assert.NotEmpty(t, shopping_list.LastModifiedAt)
+	assert.NotEmpty(t, shopping_list.Key)
+	assert.NotEmpty(t, shopping_list.ID)
+	assert.NotEmpty(t, shopping_list.CreatedAt)
+
+}
+
+func TestGeneratedStoreShoppingListQuery(t *testing.T) {
+	responseData := ` {
+	  "limit": 20,
+	  "offset": 0,
+	  "count": 1,
+	  "total": 1,
+	  "results": [
+	    {
+	      "id": "9693f04b-5aec-467f-baa1-fc74da7d0c3d",
+	      "version": 1,
+	      "name": {
+	        "en": "test"
+	      },
+	      "key": "test",
+	      "lineItems": [],
+	      "textLineItems": [],
+	      "createdAt": "2017-03-30T11:49:40.904Z",
+	      "lastModifiedAt": "2017-03-30T11:49:40.904Z"
+	    }
+	  ]
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	input := commercetools.QueryInput{}
+	queryResult, err := client.StoreShoppingListQuery(context.TODO(), "dummy-id", &input)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commercetools/service_me.go
+++ b/commercetools/service_me.go
@@ -110,6 +110,22 @@ func (client *Client) MyCartDeleteWithID(ctx context.Context, id string, version
 	return result, nil
 }
 
+// MyCartDeleteWithKey for type MyCart
+func (client *Client) MyCartDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *MyCart, err error) {
+	params := url.Values{}
+	params.Set("version", strconv.Itoa(version))
+
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("me/carts/key=%s", key)
+	err = client.delete(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // MyCartGetWithID for type MyCart
 func (client *Client) MyCartGetWithID(ctx context.Context, id string, opts ...RequestOption) (result *MyCart, err error) {
 	params := url.Values{}
@@ -117,6 +133,20 @@ func (client *Client) MyCartGetWithID(ctx context.Context, id string, opts ...Re
 		opt(&params)
 	}
 	endpoint := fmt.Sprintf("me/carts/%s", id)
+	err = client.get(ctx, endpoint, params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// MyCartGetWithKey for type MyCart
+func (client *Client) MyCartGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *MyCart, err error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+	endpoint := fmt.Sprintf("me/carts/key=%s", key)
 	err = client.get(ctx, endpoint, params, &result)
 	if err != nil {
 		return nil, err
@@ -153,6 +183,42 @@ func (client *Client) MyCartUpdateWithID(ctx context.Context, input *MyCartUpdat
 	}
 
 	endpoint := fmt.Sprintf("me/carts/%s", input.ID)
+	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// MyCartUpdateWithKeyInput is input for function MyCartUpdateWithKey
+type MyCartUpdateWithKeyInput struct {
+	Key     string
+	Version int
+	Actions []MyCartUpdateAction
+}
+
+func (input *MyCartUpdateWithKeyInput) Validate() error {
+	if input.Key == "" {
+		return fmt.Errorf("no valid value for Key given")
+	}
+	if len(input.Actions) == 0 {
+		return fmt.Errorf("no update actions specified")
+	}
+	return nil
+}
+
+// MyCartUpdateWithKey for type MyCart
+func (client *Client) MyCartUpdateWithKey(ctx context.Context, input *MyCartUpdateWithKeyInput, opts ...RequestOption) (result *MyCart, err error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	endpoint := fmt.Sprintf("me/carts/key=%s", input.Key)
 	err = client.update(ctx, endpoint, params, input.Version, input.Actions, &result)
 	if err != nil {
 		return nil, err

--- a/commercetools/service_me_generated_test.go
+++ b/commercetools/service_me_generated_test.go
@@ -14,6 +14,7 @@ func TestGeneratedMyCartGetWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -121,6 +122,127 @@ func TestGeneratedMyCartGetWithID(t *testing.T) {
 	assert.NotEmpty(t, my_cart.TaxCalculationMode)
 	assert.NotEmpty(t, my_cart.Origin)
 	assert.NotEmpty(t, my_cart.LastModifiedAt)
+	assert.NotEmpty(t, my_cart.Key)
+	assert.NotEmpty(t, my_cart.InventoryMode)
+	assert.NotEmpty(t, my_cart.ID)
+	assert.NotEmpty(t, my_cart.CreatedAt)
+	assert.NotEmpty(t, my_cart.CartState)
+
+}
+
+func TestGeneratedMyCartGetWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	my_cart, err := client.MyCartGetWithKey(context.TODO(), "dummy-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, my_cart)
+	assert.NotNil(t, my_cart.Version)
+	assert.NotEmpty(t, my_cart.TaxRoundingMode)
+	assert.NotEmpty(t, my_cart.TaxMode)
+	assert.NotEmpty(t, my_cart.TaxCalculationMode)
+	assert.NotEmpty(t, my_cart.Origin)
+	assert.NotEmpty(t, my_cart.LastModifiedAt)
+	assert.NotEmpty(t, my_cart.Key)
 	assert.NotEmpty(t, my_cart.InventoryMode)
 	assert.NotEmpty(t, my_cart.ID)
 	assert.NotEmpty(t, my_cart.CreatedAt)
@@ -132,6 +254,7 @@ func TestGeneratedMyCartDeleteWithID(t *testing.T) {
 	responseData := ` {
 	  "type": "Cart",
 	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
 	  "version": 5,
 	  "createdAt": "2015-09-22T15:36:17.510Z",
 	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
@@ -239,6 +362,127 @@ func TestGeneratedMyCartDeleteWithID(t *testing.T) {
 	assert.NotEmpty(t, my_cart.TaxCalculationMode)
 	assert.NotEmpty(t, my_cart.Origin)
 	assert.NotEmpty(t, my_cart.LastModifiedAt)
+	assert.NotEmpty(t, my_cart.Key)
+	assert.NotEmpty(t, my_cart.InventoryMode)
+	assert.NotEmpty(t, my_cart.ID)
+	assert.NotEmpty(t, my_cart.CreatedAt)
+	assert.NotEmpty(t, my_cart.CartState)
+
+}
+
+func TestGeneratedMyCartDeleteWithKey(t *testing.T) {
+	responseData := ` {
+	  "type": "Cart",
+	  "id": "2a3baa00-44fa-4ab8-bec7-933c31e18dcc",
+	  "key": "test-key",
+	  "version": 5,
+	  "createdAt": "2015-09-22T15:36:17.510Z",
+	  "lastModifiedAt": "2015-09-22T15:41:55.816Z",
+	  "lineItems": [
+	    {
+	      "id": "b925a817-d5ad-48bb-a407-29ad8e0649b5",
+	      "productId": "9f10dcfb-5cc9-4a18-843a-c07f7e22d01f",
+	      "name": {
+	        "en": "SAPPHIRE"
+	      },
+	      "productType": {
+	        "typeId": "product-type",
+	        "id": "2543e1d8-4915-4f72-a3c9-1df9b1b0082d",
+	        "version": 8
+	      },
+	      "productSlug": {
+	        "en": "sapphire1421832124423"
+	      },
+	      "variant": {
+	        "id": 1,
+	        "sku": "sku_SAPPHIRE_variant1_1421832124423",
+	        "prices": [
+	          {
+	            "value": {
+	              "type": "centPrecision",
+	              "fractionDigits": 2,
+	              "currencyCode": "EUR",
+	              "centAmount": 2800
+	            },
+	            "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	          }
+	        ],
+	        "images": [
+	          {
+	            "url": "https://www.commercetools.com/cli/data/252542005_1.jpg",
+	            "dimensions": {
+	              "w": 1400,
+	              "h": 1400
+	            }
+	          }
+	        ],
+	        "attributes": [],
+	        "assets": []
+	      },
+	      "price": {
+	        "value": {
+	          "type": "centPrecision",
+	          "fractionDigits": 2,
+	          "currencyCode": "EUR",
+	          "centAmount": 2800
+	        },
+	        "id": "8da659ef-9e54-447d-9c36-84912db1848f"
+	      },
+	      "quantity": 2,
+	      "discountedPricePerQuantity": [],
+	      "state": [
+	        {
+	          "quantity": 2,
+	          "state": {
+	            "typeId": "state",
+	            "id": "7c2e2694-aefe-43d7-888e-6a99514caaca"
+	          }
+	        }
+	      ],
+	      "priceMode": "Platform",
+	      "lineItemMode": "Standard",
+	      "totalPrice": {
+	        "type": "centPrecision",
+	        "fractionDigits": 2,
+	        "currencyCode": "EUR",
+	        "centAmount": 5600
+	      }
+	    }
+	  ],
+	  "store": {
+	    "typeId": "store",
+	    "key": "test-key"
+	  },
+	  "cartState": "Active",
+	  "totalPrice": {
+	    "type": "centPrecision",
+	    "fractionDigits": 2,
+	    "currencyCode": "EUR",
+	    "centAmount": 5600
+	  },
+	  "customLineItems": [],
+	  "discountCodes": [],
+	  "inventoryMode": "None",
+	  "taxMode": "Platform",
+	  "taxRoundingMode": "HalfEven",
+	  "taxCalculationMode": "LineItemLevel",
+	  "refusedGifts": [],
+	  "origin": "Customer"
+	} `
+	client, server := testutil.MockClient(t, responseData, nil, nil)
+	defer server.Close()
+	my_cart, err := client.MyCartDeleteWithKey(context.TODO(), "dummy-id", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, my_cart)
+	assert.NotNil(t, my_cart.Version)
+	assert.NotEmpty(t, my_cart.TaxRoundingMode)
+	assert.NotEmpty(t, my_cart.TaxMode)
+	assert.NotEmpty(t, my_cart.TaxCalculationMode)
+	assert.NotEmpty(t, my_cart.Origin)
+	assert.NotEmpty(t, my_cart.LastModifiedAt)
+	assert.NotEmpty(t, my_cart.Key)
 	assert.NotEmpty(t, my_cart.InventoryMode)
 	assert.NotEmpty(t, my_cart.ID)
 	assert.NotEmpty(t, my_cart.CreatedAt)

--- a/commercetools/service_state.go
+++ b/commercetools/service_state.go
@@ -51,14 +51,14 @@ func (client *Client) StateDeleteWithID(ctx context.Context, id string, version 
 }
 
 // StateDeleteWithKey for type State
-func (client *Client) StateDeleteWithKey(ctx context.Context, Key string, version int, opts ...RequestOption) (result *State, err error) {
+func (client *Client) StateDeleteWithKey(ctx context.Context, key string, version int, opts ...RequestOption) (result *State, err error) {
 	params := url.Values{}
 	params.Set("version", strconv.Itoa(version))
 
 	for _, opt := range opts {
 		opt(&params)
 	}
-	endpoint := fmt.Sprintf("states/key=%s", Key)
+	endpoint := fmt.Sprintf("states/key=%s", key)
 	err = client.delete(ctx, endpoint, params, &result)
 	if err != nil {
 		return nil, err
@@ -81,12 +81,12 @@ func (client *Client) StateGetWithID(ctx context.Context, id string, opts ...Req
 }
 
 // StateGetWithKey for type State
-func (client *Client) StateGetWithKey(ctx context.Context, Key string, opts ...RequestOption) (result *State, err error) {
+func (client *Client) StateGetWithKey(ctx context.Context, key string, opts ...RequestOption) (result *State, err error) {
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)
 	}
-	endpoint := fmt.Sprintf("states/key=%s", Key)
+	endpoint := fmt.Sprintf("states/key=%s", key)
 	err = client.get(ctx, endpoint, params, &result)
 	if err != nil {
 		return nil, err

--- a/commercetools/types_cart.go
+++ b/commercetools/types_cart.go
@@ -285,6 +285,20 @@ func mapDiscriminatorCartUpdateAction(input interface{}) (CartUpdateAction, erro
 			return nil, err
 		}
 		return new, nil
+	case "setBillingAddressCustomField":
+		new := CartSetBillingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setBillingAddressCustomType":
+		new := CartSetBillingAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setCartTotalTax":
 		new := CartSetCartTotalTaxAction{}
 		err := decodeStruct(input, &new)
@@ -383,6 +397,41 @@ func mapDiscriminatorCartUpdateAction(input interface{}) (CartUpdateAction, erro
 			return nil, err
 		}
 		return new, nil
+	case "setDeliveryAddressCustomField":
+		new := CartSetDeliveryAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setDeliveryAddressCustomType":
+		new := CartSetDeliveryAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomField":
+		new := CartSetItemShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomType":
+		new := CartSetItemShippingAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setKey":
+		new := CartSetKeyAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setLineItemCustomField":
 		new := CartSetLineItemCustomFieldAction{}
 		err := decodeStruct(input, &new)
@@ -448,6 +497,20 @@ func mapDiscriminatorCartUpdateAction(input interface{}) (CartUpdateAction, erro
 		return new, nil
 	case "setShippingAddress":
 		new := CartSetShippingAddressAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomField":
+		new := CartSetShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomType":
+		new := CartSetShippingAddressCustomTypeAction{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -581,6 +644,7 @@ type Cart struct {
 	LineItems                       []LineItem              `json:"lineItems"`
 	LastModifiedBy                  *LastModifiedBy         `json:"lastModifiedBy,omitempty"`
 	LastModifiedAt                  time.Time               `json:"lastModifiedAt"`
+	Key                             string                  `json:"key,omitempty"`
 	ItemShippingAddresses           []Address               `json:"itemShippingAddresses,omitempty"`
 	InventoryMode                   InventoryMode           `json:"inventoryMode,omitempty"`
 	ID                              string                  `json:"id"`
@@ -857,6 +921,7 @@ type CartDraft struct {
 	Origin                           CartOrigin                        `json:"origin,omitempty"`
 	Locale                           string                            `json:"locale,omitempty"`
 	LineItems                        []LineItemDraft                   `json:"lineItems,omitempty"`
+	Key                              string                            `json:"key,omitempty"`
 	ItemShippingAddresses            []Address                         `json:"itemShippingAddresses,omitempty"`
 	InventoryMode                    InventoryMode                     `json:"inventoryMode,omitempty"`
 	ExternalTaxRateForShippingMethod *ExternalTaxRateDraft             `json:"externalTaxRateForShippingMethod,omitempty"`
@@ -1044,6 +1109,36 @@ func (obj CartSetBillingAddressAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setBillingAddress", Alias: (*Alias)(&obj)})
+}
+
+// CartSetBillingAddressCustomFieldAction implements the interface CartUpdateAction
+type CartSetBillingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetBillingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetBillingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// CartSetBillingAddressCustomTypeAction implements the interface CartUpdateAction
+type CartSetBillingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetBillingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetBillingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // CartSetCartTotalTaxAction implements the interface CartUpdateAction
@@ -1255,6 +1350,84 @@ func (obj CartSetDeleteDaysAfterLastModificationAction) MarshalJSON() ([]byte, e
 	}{Action: "setDeleteDaysAfterLastModification", Alias: (*Alias)(&obj)})
 }
 
+// CartSetDeliveryAddressCustomFieldAction implements the interface CartUpdateAction
+type CartSetDeliveryAddressCustomFieldAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	DeliveryID string                  `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetDeliveryAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetDeliveryAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// CartSetDeliveryAddressCustomTypeAction implements the interface CartUpdateAction
+type CartSetDeliveryAddressCustomTypeAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	DeliveryID string      `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetDeliveryAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetDeliveryAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
+// CartSetItemShippingAddressCustomFieldAction implements the interface CartUpdateAction
+type CartSetItemShippingAddressCustomFieldAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	AddressKey string      `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetItemShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetItemShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// CartSetItemShippingAddressCustomTypeAction implements the interface CartUpdateAction
+type CartSetItemShippingAddressCustomTypeAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	AddressKey string                  `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetItemShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetItemShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
+// CartSetKeyAction implements the interface CartUpdateAction
+type CartSetKeyAction struct {
+	Key string `json:"key,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetKeyAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetKeyAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setKey", Alias: (*Alias)(&obj)})
+}
+
 // CartSetLineItemCustomFieldAction implements the interface CartUpdateAction
 type CartSetLineItemCustomFieldAction struct {
 	Value      interface{} `json:"value,omitempty"`
@@ -1403,6 +1576,36 @@ func (obj CartSetShippingAddressAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setShippingAddress", Alias: (*Alias)(&obj)})
+}
+
+// CartSetShippingAddressCustomFieldAction implements the interface CartUpdateAction
+type CartSetShippingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// CartSetShippingAddressCustomTypeAction implements the interface CartUpdateAction
+type CartSetShippingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartSetShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias CartSetShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // CartSetShippingMethodAction implements the interface CartUpdateAction
@@ -1598,7 +1801,20 @@ type CustomLineItemDraft struct {
 	Name            *LocalizedString               `json:"name"`
 	Money           *Money                         `json:"money"`
 	ExternalTaxRate *ExternalTaxRateDraft          `json:"externalTaxRate,omitempty"`
-	Custom          *CustomFields                  `json:"custom,omitempty"`
+	Custom          *CustomFieldsDraft             `json:"custom,omitempty"`
+}
+
+// CustomLineItemImportDraft is a standalone struct
+type CustomLineItemImportDraft struct {
+	TaxRate         *TaxRate                       `json:"taxRate,omitempty"`
+	TaxCategory     *TaxCategoryResourceIdentifier `json:"taxCategory,omitempty"`
+	State           []ItemState                    `json:"state,omitempty"`
+	Slug            string                         `json:"slug"`
+	ShippingDetails *ItemShippingDetailsDraft      `json:"shippingDetails,omitempty"`
+	Quantity        int                            `json:"quantity"`
+	Name            *LocalizedString               `json:"name"`
+	Money           *Money                         `json:"money"`
+	Custom          *CustomFieldsDraft             `json:"custom,omitempty"`
 }
 
 // DiscountCodeInfo is a standalone struct
@@ -1717,6 +1933,7 @@ type LineItem struct {
 	Price                      *Price                               `json:"price"`
 	Name                       *LocalizedString                     `json:"name"`
 	LineItemMode               LineItemMode                         `json:"lineItemMode"`
+	LastModifiedAt             *time.Time                           `json:"lastModifiedAt,omitempty"`
 	ID                         string                               `json:"id"`
 	DistributionChannel        *ChannelReference                    `json:"distributionChannel,omitempty"`
 	DiscountedPricePerQuantity []DiscountedLineItemPriceForQuantity `json:"discountedPricePerQuantity"`
@@ -1761,6 +1978,7 @@ type LineItemDraft struct {
 // ReplicaCartDraft is a standalone struct
 type ReplicaCartDraft struct {
 	Reference Reference `json:"reference"`
+	Key       string    `json:"key,omitempty"`
 }
 
 // UnmarshalJSON override to deserialize correct attribute types based
@@ -1938,32 +2156,7 @@ func (obj *TaxedPrice) UnmarshalJSON(data []byte) error {
 
 // TaxedPriceDraft is a standalone struct
 type TaxedPriceDraft struct {
-	TotalNet    TypedMoneyDraft   `json:"totalNet"`
-	TotalGross  TypedMoneyDraft   `json:"totalGross"`
+	TotalNet    *Money            `json:"totalNet"`
+	TotalGross  *Money            `json:"totalGross"`
 	TaxPortions []TaxPortionDraft `json:"taxPortions"`
-}
-
-// UnmarshalJSON override to deserialize correct attribute types based
-// on the discriminator value
-func (obj *TaxedPriceDraft) UnmarshalJSON(data []byte) error {
-	type Alias TaxedPriceDraft
-	if err := json.Unmarshal(data, (*Alias)(obj)); err != nil {
-		return err
-	}
-	if obj.TotalGross != nil {
-		var err error
-		obj.TotalGross, err = mapDiscriminatorTypedMoneyDraft(obj.TotalGross)
-		if err != nil {
-			return err
-		}
-	}
-	if obj.TotalNet != nil {
-		var err error
-		obj.TotalNet, err = mapDiscriminatorTypedMoneyDraft(obj.TotalNet)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/commercetools/types_cart_discount.go
+++ b/commercetools/types_cart_discount.go
@@ -238,6 +238,16 @@ func mapDiscriminatorCartDiscountValue(input interface{}) (CartDiscountValue, er
 			new.Money[i], err = mapDiscriminatorTypedMoney(new.Money[i])
 		}
 		return new, nil
+	case "fixed":
+		new := CartDiscountValueFixed{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		for i := range new.Money {
+			new.Money[i], err = mapDiscriminatorTypedMoney(new.Money[i])
+		}
+		return new, nil
 	case "giftLineItem":
 		new := CartDiscountValueGiftLineItem{}
 		err := decodeStruct(input, &new)
@@ -277,6 +287,13 @@ func mapDiscriminatorCartDiscountValueDraft(input interface{}) (CartDiscountValu
 			return nil, err
 		}
 		return new, nil
+	case "fixed":
+		new := CartDiscountValueFixedDraft{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "giftLineItem":
 		new := CartDiscountValueGiftLineItemDraft{}
 		err := decodeStruct(input, &new)
@@ -297,26 +314,26 @@ func mapDiscriminatorCartDiscountValueDraft(input interface{}) (CartDiscountValu
 
 // CartDiscount is of type BaseResource
 type CartDiscount struct {
-	Version              int                `json:"version"`
-	Value                CartDiscountValue  `json:"value"`
-	ValidUntil           *time.Time         `json:"validUntil,omitempty"`
-	ValidFrom            *time.Time         `json:"validFrom,omitempty"`
-	Target               CartDiscountTarget `json:"target,omitempty"`
-	StackingMode         StackingMode       `json:"stackingMode"`
-	SortOrder            string             `json:"sortOrder"`
-	RequiresDiscountCode bool               `json:"requiresDiscountCode"`
-	References           []Reference        `json:"references"`
-	Name                 *LocalizedString   `json:"name"`
-	LastModifiedBy       *LastModifiedBy    `json:"lastModifiedBy,omitempty"`
-	LastModifiedAt       time.Time          `json:"lastModifiedAt"`
-	Key                  string             `json:"key,omitempty"`
-	IsActive             bool               `json:"isActive"`
-	ID                   string             `json:"id"`
-	Description          *LocalizedString   `json:"description,omitempty"`
-	Custom               *CustomFields      `json:"custom,omitempty"`
-	CreatedBy            *CreatedBy         `json:"createdBy,omitempty"`
-	CreatedAt            time.Time          `json:"createdAt"`
-	CartPredicate        string             `json:"cartPredicate"`
+	Version              int                    `json:"version"`
+	Value                CartDiscountValueDraft `json:"value"`
+	ValidUntil           *time.Time             `json:"validUntil,omitempty"`
+	ValidFrom            *time.Time             `json:"validFrom,omitempty"`
+	Target               CartDiscountTarget     `json:"target,omitempty"`
+	StackingMode         StackingMode           `json:"stackingMode"`
+	SortOrder            string                 `json:"sortOrder"`
+	RequiresDiscountCode bool                   `json:"requiresDiscountCode"`
+	References           []Reference            `json:"references"`
+	Name                 *LocalizedString       `json:"name"`
+	LastModifiedBy       *LastModifiedBy        `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt       time.Time              `json:"lastModifiedAt"`
+	Key                  string                 `json:"key,omitempty"`
+	IsActive             bool                   `json:"isActive"`
+	ID                   string                 `json:"id"`
+	Description          *LocalizedString       `json:"description,omitempty"`
+	Custom               *CustomFields          `json:"custom,omitempty"`
+	CreatedBy            *CreatedBy             `json:"createdBy,omitempty"`
+	CreatedAt            time.Time              `json:"createdAt"`
+	CartPredicate        string                 `json:"cartPredicate"`
 }
 
 // UnmarshalJSON override to deserialize correct attribute types based
@@ -342,7 +359,7 @@ func (obj *CartDiscount) UnmarshalJSON(data []byte) error {
 	}
 	if obj.Value != nil {
 		var err error
-		obj.Value, err = mapDiscriminatorCartDiscountValue(obj.Value)
+		obj.Value, err = mapDiscriminatorCartDiscountValueDraft(obj.Value)
 		if err != nil {
 			return err
 		}
@@ -791,6 +808,52 @@ func (obj CartDiscountValueAbsoluteDraft) MarshalJSON() ([]byte, error) {
 	}{Type: "absolute", Alias: (*Alias)(&obj)})
 }
 
+// CartDiscountValueFixed implements the interface CartDiscountValue
+type CartDiscountValueFixed struct {
+	Money []TypedMoney `json:"money"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartDiscountValueFixed) MarshalJSON() ([]byte, error) {
+	type Alias CartDiscountValueFixed
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "fixed", Alias: (*Alias)(&obj)})
+}
+
+// UnmarshalJSON override to deserialize correct attribute types based
+// on the discriminator value
+func (obj *CartDiscountValueFixed) UnmarshalJSON(data []byte) error {
+	type Alias CartDiscountValueFixed
+	if err := json.Unmarshal(data, (*Alias)(obj)); err != nil {
+		return err
+	}
+	for i := range obj.Money {
+		var err error
+		obj.Money[i], err = mapDiscriminatorTypedMoney(obj.Money[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CartDiscountValueFixedDraft implements the interface CartDiscountValueDraft
+type CartDiscountValueFixedDraft struct {
+	Money []Money `json:"money"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CartDiscountValueFixedDraft) MarshalJSON() ([]byte, error) {
+	type Alias CartDiscountValueFixedDraft
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "fixed", Alias: (*Alias)(&obj)})
+}
+
 // CartDiscountValueGiftLineItem implements the interface CartDiscountValue
 type CartDiscountValueGiftLineItem struct {
 	VariantID           int               `json:"variantId"`
@@ -810,10 +873,10 @@ func (obj CartDiscountValueGiftLineItem) MarshalJSON() ([]byte, error) {
 
 // CartDiscountValueGiftLineItemDraft implements the interface CartDiscountValueDraft
 type CartDiscountValueGiftLineItemDraft struct {
-	VariantID           int               `json:"variantId"`
-	SupplyChannel       *ChannelReference `json:"supplyChannel,omitempty"`
-	Product             *ProductReference `json:"product"`
-	DistributionChannel *ChannelReference `json:"distributionChannel,omitempty"`
+	VariantID           int                        `json:"variantId"`
+	SupplyChannel       *ChannelResourceIdentifier `json:"supplyChannel,omitempty"`
+	Product             *ProductResourceIdentifier `json:"product"`
+	DistributionChannel *ChannelResourceIdentifier `json:"distributionChannel,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value

--- a/commercetools/types_channel.go
+++ b/commercetools/types_channel.go
@@ -76,6 +76,20 @@ func mapDiscriminatorChannelUpdateAction(input interface{}) (ChannelUpdateAction
 			return nil, err
 		}
 		return new, nil
+	case "setAddressCustomField":
+		new := ChannelSetAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setAddressCustomType":
+		new := ChannelSetAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setCustomField":
 		new := ChannelSetCustomFieldAction{}
 		err := decodeStruct(input, &new)
@@ -300,6 +314,36 @@ func (obj ChannelSetAddressAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setAddress", Alias: (*Alias)(&obj)})
+}
+
+// ChannelSetAddressCustomFieldAction implements the interface ChannelUpdateAction
+type ChannelSetAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ChannelSetAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias ChannelSetAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// ChannelSetAddressCustomTypeAction implements the interface ChannelUpdateAction
+type ChannelSetAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ChannelSetAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias ChannelSetAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // ChannelSetCustomFieldAction implements the interface ChannelUpdateAction

--- a/commercetools/types_common.go
+++ b/commercetools/types_common.go
@@ -22,29 +22,33 @@ type ReferenceTypeID string
 
 // Enum values for ReferenceTypeID
 const (
-	ReferenceTypeIDCart             ReferenceTypeID = "cart"
-	ReferenceTypeIDCartDiscount     ReferenceTypeID = "cart-discount"
-	ReferenceTypeIDCategory         ReferenceTypeID = "category"
-	ReferenceTypeIDChannel          ReferenceTypeID = "channel"
-	ReferenceTypeIDCustomer         ReferenceTypeID = "customer"
-	ReferenceTypeIDCustomerGroup    ReferenceTypeID = "customer-group"
-	ReferenceTypeIDDiscountCode     ReferenceTypeID = "discount-code"
-	ReferenceTypeIDKeyValueDocument ReferenceTypeID = "key-value-document"
-	ReferenceTypeIDPayment          ReferenceTypeID = "payment"
-	ReferenceTypeIDProduct          ReferenceTypeID = "product"
-	ReferenceTypeIDProductType      ReferenceTypeID = "product-type"
-	ReferenceTypeIDProductDiscount  ReferenceTypeID = "product-discount"
-	ReferenceTypeIDOrder            ReferenceTypeID = "order"
-	ReferenceTypeIDReview           ReferenceTypeID = "review"
-	ReferenceTypeIDShoppingList     ReferenceTypeID = "shopping-list"
-	ReferenceTypeIDShippingMethod   ReferenceTypeID = "shipping-method"
-	ReferenceTypeIDState            ReferenceTypeID = "state"
-	ReferenceTypeIDStore            ReferenceTypeID = "store"
-	ReferenceTypeIDTaxCategory      ReferenceTypeID = "tax-category"
-	ReferenceTypeIDType             ReferenceTypeID = "type"
-	ReferenceTypeIDZone             ReferenceTypeID = "zone"
-	ReferenceTypeIDInventoryEntry   ReferenceTypeID = "inventory-entry"
-	ReferenceTypeIDOrderEdit        ReferenceTypeID = "order-edit"
+	ReferenceTypeIDCart                  ReferenceTypeID = "cart"
+	ReferenceTypeIDCartDiscount          ReferenceTypeID = "cart-discount"
+	ReferenceTypeIDCategory              ReferenceTypeID = "category"
+	ReferenceTypeIDChannel               ReferenceTypeID = "channel"
+	ReferenceTypeIDCustomer              ReferenceTypeID = "customer"
+	ReferenceTypeIDCustomerEmailToken    ReferenceTypeID = "customer-email-token"
+	ReferenceTypeIDCustomerGroup         ReferenceTypeID = "customer-group"
+	ReferenceTypeIDCustomerPasswordToken ReferenceTypeID = "customer-password-token"
+	ReferenceTypeIDDiscountCode          ReferenceTypeID = "discount-code"
+	ReferenceTypeIDExtension             ReferenceTypeID = "extension"
+	ReferenceTypeIDInventoryEntry        ReferenceTypeID = "inventory-entry"
+	ReferenceTypeIDKeyValueDocument      ReferenceTypeID = "key-value-document"
+	ReferenceTypeIDOrder                 ReferenceTypeID = "order"
+	ReferenceTypeIDOrderEdit             ReferenceTypeID = "order-edit"
+	ReferenceTypeIDPayment               ReferenceTypeID = "payment"
+	ReferenceTypeIDProduct               ReferenceTypeID = "product"
+	ReferenceTypeIDProductDiscount       ReferenceTypeID = "product-discount"
+	ReferenceTypeIDProductType           ReferenceTypeID = "product-type"
+	ReferenceTypeIDReview                ReferenceTypeID = "review"
+	ReferenceTypeIDShippingMethod        ReferenceTypeID = "shipping-method"
+	ReferenceTypeIDShoppingList          ReferenceTypeID = "shopping-list"
+	ReferenceTypeIDState                 ReferenceTypeID = "state"
+	ReferenceTypeIDStore                 ReferenceTypeID = "store"
+	ReferenceTypeIDSubscription          ReferenceTypeID = "subscription"
+	ReferenceTypeIDTaxCategory           ReferenceTypeID = "tax-category"
+	ReferenceTypeIDType                  ReferenceTypeID = "type"
+	ReferenceTypeIDZone                  ReferenceTypeID = "zone"
 )
 
 // CountryCode is of type string
@@ -526,31 +530,32 @@ func mapDiscriminatorTypedMoneyDraft(input interface{}) (TypedMoneyDraft, error)
 
 // Address is a standalone struct
 type Address struct {
-	Title                 string      `json:"title,omitempty"`
-	StreetNumber          string      `json:"streetNumber,omitempty"`
-	StreetName            string      `json:"streetName,omitempty"`
-	State                 string      `json:"state,omitempty"`
-	Salutation            string      `json:"salutation,omitempty"`
-	Region                string      `json:"region,omitempty"`
-	PostalCode            string      `json:"postalCode,omitempty"`
-	Phone                 string      `json:"phone,omitempty"`
-	POBox                 string      `json:"pOBox,omitempty"`
-	Mobile                string      `json:"mobile,omitempty"`
-	LastName              string      `json:"lastName,omitempty"`
-	Key                   string      `json:"key,omitempty"`
-	ID                    string      `json:"id,omitempty"`
-	FirstName             string      `json:"firstName,omitempty"`
-	Fax                   string      `json:"fax,omitempty"`
-	ExternalID            string      `json:"externalId,omitempty"`
-	Email                 string      `json:"email,omitempty"`
-	Department            string      `json:"department,omitempty"`
-	Country               CountryCode `json:"country"`
-	Company               string      `json:"company,omitempty"`
-	City                  string      `json:"city,omitempty"`
-	Building              string      `json:"building,omitempty"`
-	Apartment             string      `json:"apartment,omitempty"`
-	AdditionalStreetInfo  string      `json:"additionalStreetInfo,omitempty"`
-	AdditionalAddressInfo string      `json:"additionalAddressInfo,omitempty"`
+	Title                 string        `json:"title,omitempty"`
+	StreetNumber          string        `json:"streetNumber,omitempty"`
+	StreetName            string        `json:"streetName,omitempty"`
+	State                 string        `json:"state,omitempty"`
+	Salutation            string        `json:"salutation,omitempty"`
+	Region                string        `json:"region,omitempty"`
+	PostalCode            string        `json:"postalCode,omitempty"`
+	Phone                 string        `json:"phone,omitempty"`
+	POBox                 string        `json:"pOBox,omitempty"`
+	Mobile                string        `json:"mobile,omitempty"`
+	LastName              string        `json:"lastName,omitempty"`
+	Key                   string        `json:"key,omitempty"`
+	ID                    string        `json:"id,omitempty"`
+	FirstName             string        `json:"firstName,omitempty"`
+	Fax                   string        `json:"fax,omitempty"`
+	ExternalID            string        `json:"externalId,omitempty"`
+	Email                 string        `json:"email,omitempty"`
+	Department            string        `json:"department,omitempty"`
+	Custom                *CustomFields `json:"custom,omitempty"`
+	Country               CountryCode   `json:"country"`
+	Company               string        `json:"company,omitempty"`
+	City                  string        `json:"city,omitempty"`
+	Building              string        `json:"building,omitempty"`
+	Apartment             string        `json:"apartment,omitempty"`
+	AdditionalStreetInfo  string        `json:"additionalStreetInfo,omitempty"`
+	AdditionalAddressInfo string        `json:"additionalAddressInfo,omitempty"`
 }
 
 // Asset is a standalone struct
@@ -614,8 +619,9 @@ func (obj CentPrecisionMoney) MarshalJSON() ([]byte, error) {
 
 // CentPrecisionMoneyDraft implements the interface TypedMoneyDraft
 type CentPrecisionMoneyDraft struct {
-	CurrencyCode CurrencyCode `json:"currencyCode"`
-	CentAmount   int          `json:"centAmount"`
+	CurrencyCode   CurrencyCode `json:"currencyCode"`
+	CentAmount     int          `json:"centAmount"`
+	FractionDigits float64      `json:"fractionDigits,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -682,9 +688,10 @@ func (obj HighPrecisionMoney) MarshalJSON() ([]byte, error) {
 
 // HighPrecisionMoneyDraft implements the interface TypedMoneyDraft
 type HighPrecisionMoneyDraft struct {
-	CurrencyCode  CurrencyCode `json:"currencyCode"`
-	CentAmount    int          `json:"centAmount"`
-	PreciseAmount int          `json:"preciseAmount"`
+	CurrencyCode   CurrencyCode `json:"currencyCode"`
+	CentAmount     int          `json:"centAmount"`
+	FractionDigits float64      `json:"fractionDigits,omitempty"`
+	PreciseAmount  int          `json:"preciseAmount"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -730,7 +737,6 @@ type PagedQueryResponse struct {
 	Offset  int            `json:"offset"`
 	Meta    interface{}    `json:"meta,omitempty"`
 	Limit   int            `json:"limit"`
-	Facets  *FacetResults  `json:"facets,omitempty"`
 	Count   int            `json:"count"`
 }
 

--- a/commercetools/types_customer.go
+++ b/commercetools/types_customer.go
@@ -101,6 +101,20 @@ func mapDiscriminatorCustomerUpdateAction(input interface{}) (CustomerUpdateActi
 			return nil, err
 		}
 		return new, nil
+	case "setAddressCustomField":
+		new := CustomerSetAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setAddressCustomType":
+		new := CustomerSetAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setCompanyName":
 		new := CustomerSetCompanyNameAction{}
 		err := decodeStruct(input, &new)
@@ -399,6 +413,7 @@ type CustomerDraft struct {
 	BillingAddresses       []int                            `json:"billingAddresses,omitempty"`
 	AnonymousID            string                           `json:"anonymousId,omitempty"`
 	AnonymousCartID        string                           `json:"anonymousCartId,omitempty"`
+	AnonymousCart          *CartResourceIdentifier          `json:"anonymousCart,omitempty"`
 	Addresses              []Address                        `json:"addresses,omitempty"`
 }
 
@@ -511,6 +526,38 @@ func (obj CustomerResourceIdentifier) MarshalJSON() ([]byte, error) {
 		TypeID string `json:"typeId"`
 		*Alias
 	}{TypeID: "customer", Alias: (*Alias)(&obj)})
+}
+
+// CustomerSetAddressCustomFieldAction implements the interface CustomerUpdateAction
+type CustomerSetAddressCustomFieldAction struct {
+	Value     interface{} `json:"value,omitempty"`
+	Name      string      `json:"name"`
+	AddressID string      `json:"addressId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CustomerSetAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias CustomerSetAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// CustomerSetAddressCustomTypeAction implements the interface CustomerUpdateAction
+type CustomerSetAddressCustomTypeAction struct {
+	Type      *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields    *FieldContainer         `json:"fields,omitempty"`
+	AddressID string                  `json:"addressId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CustomerSetAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias CustomerSetAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // CustomerSetCompanyNameAction implements the interface CustomerUpdateAction
@@ -771,8 +818,8 @@ func (obj CustomerSetVatIDAction) MarshalJSON() ([]byte, error) {
 
 // CustomerSignInResult is a standalone struct
 type CustomerSignInResult struct {
-	Customer *Customer   `json:"customer"`
-	Cart     interface{} `json:"cart,omitempty"`
+	Customer *Customer `json:"customer"`
+	Cart     *Cart     `json:"cart,omitempty"`
 }
 
 // CustomerSignin is a standalone struct
@@ -783,6 +830,7 @@ type CustomerSignin struct {
 	AnonymousID             string                  `json:"anonymousId,omitempty"`
 	AnonymousCartSignInMode AnonymousCartSignInMode `json:"anonymousCartSignInMode,omitempty"`
 	AnonymousCartID         string                  `json:"anonymousCartId,omitempty"`
+	AnonymousCart           *CartResourceIdentifier `json:"anonymousCart,omitempty"`
 }
 
 // CustomerToken is a standalone struct

--- a/commercetools/types_error.go
+++ b/commercetools/types_error.go
@@ -29,6 +29,34 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "AnonymousIdAlreadyInUse":
+		new := AnonymousIdAlreadyInUseError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "AttributeDefinitionAlreadyExists":
+		new := AttributeDefinitionAlreadyExistsError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "AttributeDefinitionTypeConflict":
+		new := AttributeDefinitionTypeConflictError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "AttributeNameDoesNotExist":
+		new := AttributeNameDoesNotExistError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "ConcurrentModification":
 		new := ConcurrentModificationError{}
 		err := decodeStruct(input, &new)
@@ -52,6 +80,13 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 		return new, nil
 	case "DuplicateAttributeValues":
 		new := DuplicateAttributeValuesError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "DuplicateEnumValues":
+		new := DuplicateEnumValuesError{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -97,8 +132,36 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "EditPreviewFailed":
+		new := EditPreviewFailedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "EnumKeyAlreadyExists":
+		new := EnumKeyAlreadyExistsError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "EnumKeyDoesNotExist":
+		new := EnumKeyDoesNotExistError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "EnumValueIsUsed":
 		new := EnumValueIsUsedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "EnumValuesMustMatch":
+		new := EnumValuesMustMatchError{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -125,8 +188,36 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "ExternalOAuthFailed":
+		new := ExternalOAuthFailedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "FeatureRemoved":
+		new := FeatureRemovedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "General":
+		new := GeneralError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "insufficient_scope":
 		new := InsufficientScopeError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "InternalConstraintViolated":
+		new := InternalConstraintViolatedError{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -209,6 +300,20 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "MaxResourceLimitExceeded":
+		new := MaxResourceLimitExceededError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "MissingRoleOnChannel":
+		new := MissingRoleOnChannelError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "MissingTaxRateForCountry":
 		new := MissingTaxRateForCountryError{}
 		err := decodeStruct(input, &new)
@@ -223,6 +328,20 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "NotEnabled":
+		new := NotEnabledError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "ObjectNotFound":
+		new := ObjectNotFoundError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "OutOfStock":
 		new := OutOfStockError{}
 		err := decodeStruct(input, &new)
@@ -230,8 +349,43 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "OverCapacity":
+		new := OverCapacityError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "PendingOperation":
+		new := PendingOperationError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "PriceChanged":
 		new := PriceChangedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "ProjectNotConfiguredForLanguages":
+		new := ProjectNotConfiguredForLanguagesError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "QueryComplexityLimitExceeded":
+		new := QueryComplexityLimitExceededError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "QueryTimedOut":
+		new := QueryTimedOutError{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -265,8 +419,64 @@ func mapDiscriminatorErrorObject(input interface{}) (ErrorObject, error) {
 			return nil, err
 		}
 		return new, nil
+	case "ResourceSizeLimitExceeded":
+		new := ResourceSizeLimitExceededError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SearchDeactivated":
+		new := SearchDeactivatedError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SearchExecutionFailure":
+		new := SearchExecutionFailureError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SearchFacetPathNotFound":
+		new := SearchFacetPathNotFoundError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SearchIndexingInProgress":
+		new := SearchIndexingInProgressError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SemanticError":
+		new := SemanticErrorError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "ShippingMethodDoesNotMatchCart":
 		new := ShippingMethodDoesNotMatchCartError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "SyntaxError":
+		new := SyntaxErrorError{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "WeakPassword":
+		new := WeakPasswordError{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -291,6 +501,85 @@ func (obj AccessDeniedError) MarshalJSON() ([]byte, error) {
 }
 
 func (obj AccessDeniedError) Error() string {
+	return obj.Message
+}
+
+// AnonymousIdAlreadyInUseError implements the interface ErrorObject
+type AnonymousIdAlreadyInUseError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj AnonymousIdAlreadyInUseError) MarshalJSON() ([]byte, error) {
+	type Alias AnonymousIdAlreadyInUseError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "AnonymousIdAlreadyInUse", Alias: (*Alias)(&obj)})
+}
+
+func (obj AnonymousIdAlreadyInUseError) Error() string {
+	return obj.Message
+}
+
+// AttributeDefinitionAlreadyExistsError implements the interface ErrorObject
+type AttributeDefinitionAlreadyExistsError struct {
+	Message                    string `json:"message"`
+	ConflictingProductTypeName string `json:"conflictingProductTypeName"`
+	ConflictingProductTypeID   string `json:"conflictingProductTypeId"`
+	ConflictingAttributeName   string `json:"conflictingAttributeName"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj AttributeDefinitionAlreadyExistsError) MarshalJSON() ([]byte, error) {
+	type Alias AttributeDefinitionAlreadyExistsError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "AttributeDefinitionAlreadyExists", Alias: (*Alias)(&obj)})
+}
+
+func (obj AttributeDefinitionAlreadyExistsError) Error() string {
+	return obj.Message
+}
+
+// AttributeDefinitionTypeConflictError implements the interface ErrorObject
+type AttributeDefinitionTypeConflictError struct {
+	Message                    string `json:"message"`
+	ConflictingProductTypeName string `json:"conflictingProductTypeName"`
+	ConflictingProductTypeID   string `json:"conflictingProductTypeId"`
+	ConflictingAttributeName   string `json:"conflictingAttributeName"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj AttributeDefinitionTypeConflictError) MarshalJSON() ([]byte, error) {
+	type Alias AttributeDefinitionTypeConflictError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "AttributeDefinitionTypeConflict", Alias: (*Alias)(&obj)})
+}
+
+func (obj AttributeDefinitionTypeConflictError) Error() string {
+	return obj.Message
+}
+
+// AttributeNameDoesNotExistError implements the interface ErrorObject
+type AttributeNameDoesNotExistError struct {
+	Message              string `json:"message"`
+	InvalidAttributeName string `json:"invalidAttributeName"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj AttributeNameDoesNotExistError) MarshalJSON() ([]byte, error) {
+	type Alias AttributeNameDoesNotExistError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "AttributeNameDoesNotExist", Alias: (*Alias)(&obj)})
+}
+
+func (obj AttributeNameDoesNotExistError) Error() string {
 	return obj.Message
 }
 
@@ -372,6 +661,25 @@ func (obj DuplicateAttributeValuesError) MarshalJSON() ([]byte, error) {
 }
 
 func (obj DuplicateAttributeValuesError) Error() string {
+	return obj.Message
+}
+
+// DuplicateEnumValuesError implements the interface ErrorObject
+type DuplicateEnumValuesError struct {
+	Message    string   `json:"message"`
+	Duplicates []string `json:"duplicates"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj DuplicateEnumValuesError) MarshalJSON() ([]byte, error) {
+	type Alias DuplicateEnumValuesError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "DuplicateEnumValues", Alias: (*Alias)(&obj)})
+}
+
+func (obj DuplicateEnumValuesError) Error() string {
 	return obj.Message
 }
 
@@ -491,6 +799,65 @@ func (obj DuplicateVariantValuesError) Error() string {
 	return obj.Message
 }
 
+// EditPreviewFailedError implements the interface ErrorObject
+type EditPreviewFailedError struct {
+	Message string                   `json:"message"`
+	Result  *OrderEditPreviewFailure `json:"result"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj EditPreviewFailedError) MarshalJSON() ([]byte, error) {
+	type Alias EditPreviewFailedError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "EditPreviewFailed", Alias: (*Alias)(&obj)})
+}
+
+func (obj EditPreviewFailedError) Error() string {
+	return obj.Message
+}
+
+// EnumKeyAlreadyExistsError implements the interface ErrorObject
+type EnumKeyAlreadyExistsError struct {
+	Message                  string `json:"message"`
+	ConflictingEnumKey       string `json:"conflictingEnumKey"`
+	ConflictingAttributeName string `json:"conflictingAttributeName"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj EnumKeyAlreadyExistsError) MarshalJSON() ([]byte, error) {
+	type Alias EnumKeyAlreadyExistsError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "EnumKeyAlreadyExists", Alias: (*Alias)(&obj)})
+}
+
+func (obj EnumKeyAlreadyExistsError) Error() string {
+	return obj.Message
+}
+
+// EnumKeyDoesNotExistError implements the interface ErrorObject
+type EnumKeyDoesNotExistError struct {
+	Message                  string `json:"message"`
+	ConflictingEnumKey       string `json:"conflictingEnumKey"`
+	ConflictingAttributeName string `json:"conflictingAttributeName"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj EnumKeyDoesNotExistError) MarshalJSON() ([]byte, error) {
+	type Alias EnumKeyDoesNotExistError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "EnumKeyDoesNotExist", Alias: (*Alias)(&obj)})
+}
+
+func (obj EnumKeyDoesNotExistError) Error() string {
+	return obj.Message
+}
+
 // EnumValueIsUsedError implements the interface ErrorObject
 type EnumValueIsUsedError struct {
 	Message string `json:"message"`
@@ -506,6 +873,24 @@ func (obj EnumValueIsUsedError) MarshalJSON() ([]byte, error) {
 }
 
 func (obj EnumValueIsUsedError) Error() string {
+	return obj.Message
+}
+
+// EnumValuesMustMatchError implements the interface ErrorObject
+type EnumValuesMustMatchError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj EnumValuesMustMatchError) MarshalJSON() ([]byte, error) {
+	type Alias EnumValuesMustMatchError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "EnumValuesMustMatch", Alias: (*Alias)(&obj)})
+}
+
+func (obj EnumValuesMustMatchError) Error() string {
 	return obj.Message
 }
 
@@ -569,10 +954,9 @@ func (obj ExtensionBadResponseError) Error() string {
 
 // ExtensionNoResponseError implements the interface ErrorObject
 type ExtensionNoResponseError struct {
-	Message            string            `json:"message"`
-	LocalizedMessage   *LocalizedString  `json:"localizedMessage,omitempty"`
-	ExtensionExtraInfo interface{}       `json:"extensionExtraInfo,omitempty"`
-	ErrorByExtension   *ErrorByExtension `json:"errorByExtension"`
+	Message      string `json:"message"`
+	ExtensionKey string `json:"extensionKey,omitempty"`
+	ExtensionID  string `json:"extensionId"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -609,6 +993,60 @@ func (obj ExtensionUpdateActionsFailedError) Error() string {
 	return obj.Message
 }
 
+// ExternalOAuthFailedError implements the interface ErrorObject
+type ExternalOAuthFailedError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ExternalOAuthFailedError) MarshalJSON() ([]byte, error) {
+	type Alias ExternalOAuthFailedError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "ExternalOAuthFailed", Alias: (*Alias)(&obj)})
+}
+
+func (obj ExternalOAuthFailedError) Error() string {
+	return obj.Message
+}
+
+// FeatureRemovedError implements the interface ErrorObject
+type FeatureRemovedError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj FeatureRemovedError) MarshalJSON() ([]byte, error) {
+	type Alias FeatureRemovedError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "FeatureRemoved", Alias: (*Alias)(&obj)})
+}
+
+func (obj FeatureRemovedError) Error() string {
+	return obj.Message
+}
+
+// GeneralError implements the interface ErrorObject
+type GeneralError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj GeneralError) MarshalJSON() ([]byte, error) {
+	type Alias GeneralError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "General", Alias: (*Alias)(&obj)})
+}
+
+func (obj GeneralError) Error() string {
+	return obj.Message
+}
+
 // InsufficientScopeError implements the interface ErrorObject
 type InsufficientScopeError struct {
 	Message string `json:"message"`
@@ -624,6 +1062,24 @@ func (obj InsufficientScopeError) MarshalJSON() ([]byte, error) {
 }
 
 func (obj InsufficientScopeError) Error() string {
+	return obj.Message
+}
+
+// InternalConstraintViolatedError implements the interface ErrorObject
+type InternalConstraintViolatedError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj InternalConstraintViolatedError) MarshalJSON() ([]byte, error) {
+	type Alias InternalConstraintViolatedError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "InternalConstraintViolated", Alias: (*Alias)(&obj)})
+}
+
+func (obj InternalConstraintViolatedError) Error() string {
 	return obj.Message
 }
 
@@ -836,6 +1292,45 @@ func (obj MatchingPriceNotFoundError) Error() string {
 	return obj.Message
 }
 
+// MaxResourceLimitExceededError implements the interface ErrorObject
+type MaxResourceLimitExceededError struct {
+	Message          string          `json:"message"`
+	ExceededResource ReferenceTypeID `json:"exceededResource"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj MaxResourceLimitExceededError) MarshalJSON() ([]byte, error) {
+	type Alias MaxResourceLimitExceededError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "MaxResourceLimitExceeded", Alias: (*Alias)(&obj)})
+}
+
+func (obj MaxResourceLimitExceededError) Error() string {
+	return obj.Message
+}
+
+// MissingRoleOnChannelError implements the interface ErrorObject
+type MissingRoleOnChannelError struct {
+	Message     string                     `json:"message"`
+	MissingRole ChannelRoleEnum            `json:"missingRole"`
+	Channel     *ChannelResourceIdentifier `json:"channel,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj MissingRoleOnChannelError) MarshalJSON() ([]byte, error) {
+	type Alias MissingRoleOnChannelError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "MissingRoleOnChannel", Alias: (*Alias)(&obj)})
+}
+
+func (obj MissingRoleOnChannelError) Error() string {
+	return obj.Message
+}
+
 // MissingTaxRateForCountryError implements the interface ErrorObject
 type MissingTaxRateForCountryError struct {
 	Message       string `json:"message"`
@@ -875,6 +1370,42 @@ func (obj NoMatchingProductDiscountFoundError) Error() string {
 	return obj.Message
 }
 
+// NotEnabledError implements the interface ErrorObject
+type NotEnabledError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj NotEnabledError) MarshalJSON() ([]byte, error) {
+	type Alias NotEnabledError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "NotEnabled", Alias: (*Alias)(&obj)})
+}
+
+func (obj NotEnabledError) Error() string {
+	return obj.Message
+}
+
+// ObjectNotFoundError implements the interface ErrorObject
+type ObjectNotFoundError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ObjectNotFoundError) MarshalJSON() ([]byte, error) {
+	type Alias ObjectNotFoundError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "ObjectNotFound", Alias: (*Alias)(&obj)})
+}
+
+func (obj ObjectNotFoundError) Error() string {
+	return obj.Message
+}
+
 // OutOfStockError implements the interface ErrorObject
 type OutOfStockError struct {
 	Message   string   `json:"message"`
@@ -895,6 +1426,42 @@ func (obj OutOfStockError) Error() string {
 	return obj.Message
 }
 
+// OverCapacityError implements the interface ErrorObject
+type OverCapacityError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OverCapacityError) MarshalJSON() ([]byte, error) {
+	type Alias OverCapacityError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "OverCapacity", Alias: (*Alias)(&obj)})
+}
+
+func (obj OverCapacityError) Error() string {
+	return obj.Message
+}
+
+// PendingOperationError implements the interface ErrorObject
+type PendingOperationError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj PendingOperationError) MarshalJSON() ([]byte, error) {
+	type Alias PendingOperationError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "PendingOperation", Alias: (*Alias)(&obj)})
+}
+
+func (obj PendingOperationError) Error() string {
+	return obj.Message
+}
+
 // PriceChangedError implements the interface ErrorObject
 type PriceChangedError struct {
 	Message   string   `json:"message"`
@@ -912,6 +1479,61 @@ func (obj PriceChangedError) MarshalJSON() ([]byte, error) {
 }
 
 func (obj PriceChangedError) Error() string {
+	return obj.Message
+}
+
+// ProjectNotConfiguredForLanguagesError implements the interface ErrorObject
+type ProjectNotConfiguredForLanguagesError struct {
+	Message   string   `json:"message"`
+	Languages []string `json:"languages,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ProjectNotConfiguredForLanguagesError) MarshalJSON() ([]byte, error) {
+	type Alias ProjectNotConfiguredForLanguagesError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "ProjectNotConfiguredForLanguages", Alias: (*Alias)(&obj)})
+}
+
+func (obj ProjectNotConfiguredForLanguagesError) Error() string {
+	return obj.Message
+}
+
+// QueryComplexityLimitExceededError implements the interface ErrorObject
+type QueryComplexityLimitExceededError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj QueryComplexityLimitExceededError) MarshalJSON() ([]byte, error) {
+	type Alias QueryComplexityLimitExceededError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "QueryComplexityLimitExceeded", Alias: (*Alias)(&obj)})
+}
+
+func (obj QueryComplexityLimitExceededError) Error() string {
+	return obj.Message
+}
+
+// QueryTimedOutError implements the interface ErrorObject
+type QueryTimedOutError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj QueryTimedOutError) MarshalJSON() ([]byte, error) {
+	type Alias QueryTimedOutError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "QueryTimedOut", Alias: (*Alias)(&obj)})
+}
+
+func (obj QueryTimedOutError) Error() string {
 	return obj.Message
 }
 
@@ -992,6 +1614,114 @@ func (obj ResourceNotFoundError) Error() string {
 	return obj.Message
 }
 
+// ResourceSizeLimitExceededError implements the interface ErrorObject
+type ResourceSizeLimitExceededError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ResourceSizeLimitExceededError) MarshalJSON() ([]byte, error) {
+	type Alias ResourceSizeLimitExceededError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "ResourceSizeLimitExceeded", Alias: (*Alias)(&obj)})
+}
+
+func (obj ResourceSizeLimitExceededError) Error() string {
+	return obj.Message
+}
+
+// SearchDeactivatedError implements the interface ErrorObject
+type SearchDeactivatedError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SearchDeactivatedError) MarshalJSON() ([]byte, error) {
+	type Alias SearchDeactivatedError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SearchDeactivated", Alias: (*Alias)(&obj)})
+}
+
+func (obj SearchDeactivatedError) Error() string {
+	return obj.Message
+}
+
+// SearchExecutionFailureError implements the interface ErrorObject
+type SearchExecutionFailureError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SearchExecutionFailureError) MarshalJSON() ([]byte, error) {
+	type Alias SearchExecutionFailureError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SearchExecutionFailure", Alias: (*Alias)(&obj)})
+}
+
+func (obj SearchExecutionFailureError) Error() string {
+	return obj.Message
+}
+
+// SearchFacetPathNotFoundError implements the interface ErrorObject
+type SearchFacetPathNotFoundError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SearchFacetPathNotFoundError) MarshalJSON() ([]byte, error) {
+	type Alias SearchFacetPathNotFoundError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SearchFacetPathNotFound", Alias: (*Alias)(&obj)})
+}
+
+func (obj SearchFacetPathNotFoundError) Error() string {
+	return obj.Message
+}
+
+// SearchIndexingInProgressError implements the interface ErrorObject
+type SearchIndexingInProgressError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SearchIndexingInProgressError) MarshalJSON() ([]byte, error) {
+	type Alias SearchIndexingInProgressError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SearchIndexingInProgress", Alias: (*Alias)(&obj)})
+}
+
+func (obj SearchIndexingInProgressError) Error() string {
+	return obj.Message
+}
+
+// SemanticErrorError implements the interface ErrorObject
+type SemanticErrorError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SemanticErrorError) MarshalJSON() ([]byte, error) {
+	type Alias SemanticErrorError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SemanticError", Alias: (*Alias)(&obj)})
+}
+
+func (obj SemanticErrorError) Error() string {
+	return obj.Message
+}
+
 // ShippingMethodDoesNotMatchCartError implements the interface ErrorObject
 type ShippingMethodDoesNotMatchCartError struct {
 	Message string `json:"message"`
@@ -1010,9 +1740,45 @@ func (obj ShippingMethodDoesNotMatchCartError) Error() string {
 	return obj.Message
 }
 
+// SyntaxErrorError implements the interface ErrorObject
+type SyntaxErrorError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj SyntaxErrorError) MarshalJSON() ([]byte, error) {
+	type Alias SyntaxErrorError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "SyntaxError", Alias: (*Alias)(&obj)})
+}
+
+func (obj SyntaxErrorError) Error() string {
+	return obj.Message
+}
+
 // VariantValues is a standalone struct
 type VariantValues struct {
 	SKU        string       `json:"sku,omitempty"`
 	Prices     []PriceDraft `json:"prices"`
 	Attributes []Attribute  `json:"attributes"`
+}
+
+// WeakPasswordError implements the interface ErrorObject
+type WeakPasswordError struct {
+	Message string `json:"message"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj WeakPasswordError) MarshalJSON() ([]byte, error) {
+	type Alias WeakPasswordError
+	return json.Marshal(struct {
+		Code string `json:"code"`
+		*Alias
+	}{Code: "WeakPassword", Alias: (*Alias)(&obj)})
+}
+
+func (obj WeakPasswordError) Error() string {
+	return obj.Message
 }

--- a/commercetools/types_me.go
+++ b/commercetools/types_me.go
@@ -603,6 +603,7 @@ type MyCart struct {
 	LineItems                       []LineItem              `json:"lineItems"`
 	LastModifiedBy                  *LastModifiedBy         `json:"lastModifiedBy,omitempty"`
 	LastModifiedAt                  time.Time               `json:"lastModifiedAt"`
+	Key                             string                  `json:"key,omitempty"`
 	ItemShippingAddresses           []Address               `json:"itemShippingAddresses,omitempty"`
 	InventoryMode                   InventoryMode           `json:"inventoryMode,omitempty"`
 	ID                              string                  `json:"id"`
@@ -680,7 +681,7 @@ type MyCartAddLineItemAction struct {
 	SupplyChannel       *ChannelResourceIdentifier  `json:"supplyChannel,omitempty"`
 	SKU                 string                      `json:"sku,omitempty"`
 	ShippingDetails     *ItemShippingDetailsDraft   `json:"shippingDetails,omitempty"`
-	Quantity            float64                     `json:"quantity,omitempty"`
+	Quantity            int                         `json:"quantity,omitempty"`
 	ProductID           string                      `json:"productId,omitempty"`
 	ExternalTotalPrice  *ExternalLineItemTotalPrice `json:"externalTotalPrice,omitempty"`
 	ExternalTaxRate     *ExternalTaxRateDraft       `json:"externalTaxRate,omitempty"`
@@ -730,7 +731,7 @@ func (obj MyCartApplyDeltaToLineItemShippingDetailsTargetsAction) MarshalJSON() 
 
 // MyCartChangeLineItemQuantityAction implements the interface MyCartUpdateAction
 type MyCartChangeLineItemQuantityAction struct {
-	Quantity           float64                     `json:"quantity"`
+	Quantity           int                         `json:"quantity"`
 	LineItemID         string                      `json:"lineItemId"`
 	ExternalTotalPrice *ExternalLineItemTotalPrice `json:"externalTotalPrice,omitempty"`
 	ExternalPrice      *Money                      `json:"externalPrice,omitempty"`
@@ -762,12 +763,14 @@ func (obj MyCartChangeTaxModeAction) MarshalJSON() ([]byte, error) {
 // MyCartDraft is a standalone struct
 type MyCartDraft struct {
 	TaxMode                         TaxMode                           `json:"taxMode,omitempty"`
+	Store                           *StoreKeyReference                `json:"store,omitempty"`
 	ShippingMethod                  *ShippingMethodResourceIdentifier `json:"shippingMethod,omitempty"`
 	ShippingAddress                 *Address                          `json:"shippingAddress,omitempty"`
 	Locale                          string                            `json:"locale,omitempty"`
 	LineItems                       []MyLineItemDraft                 `json:"lineItems,omitempty"`
 	ItemShippingAddresses           []Address                         `json:"itemShippingAddresses,omitempty"`
 	InventoryMode                   InventoryMode                     `json:"inventoryMode,omitempty"`
+	DiscountCodes                   []DiscountCodeInfo                `json:"discountCodes,omitempty"`
 	DeleteDaysAfterLastModification int                               `json:"deleteDaysAfterLastModification,omitempty"`
 	CustomerEmail                   string                            `json:"customerEmail,omitempty"`
 	Custom                          *CustomFieldsDraft                `json:"custom,omitempty"`
@@ -821,7 +824,7 @@ func (obj MyCartRemoveItemShippingAddressAction) MarshalJSON() ([]byte, error) {
 // MyCartRemoveLineItemAction implements the interface MyCartUpdateAction
 type MyCartRemoveLineItemAction struct {
 	ShippingDetailsToRemove *ItemShippingDetailsDraft   `json:"shippingDetailsToRemove,omitempty"`
-	Quantity                float64                     `json:"quantity,omitempty"`
+	Quantity                int                         `json:"quantity,omitempty"`
 	LineItemID              string                      `json:"lineItemId"`
 	ExternalTotalPrice      *ExternalLineItemTotalPrice `json:"externalTotalPrice,omitempty"`
 	ExternalPrice           *Money                      `json:"externalPrice,omitempty"`
@@ -1044,6 +1047,30 @@ func (obj MyCartSetShippingMethodAction) MarshalJSON() ([]byte, error) {
 	}{Action: "setShippingMethod", Alias: (*Alias)(&obj)})
 }
 
+// MyCartUpdate is a standalone struct
+type MyCartUpdate struct {
+	Version int                  `json:"version"`
+	Actions []MyCartUpdateAction `json:"actions"`
+}
+
+// UnmarshalJSON override to deserialize correct attribute types based
+// on the discriminator value
+func (obj *MyCartUpdate) UnmarshalJSON(data []byte) error {
+	type Alias MyCartUpdate
+	if err := json.Unmarshal(data, (*Alias)(obj)); err != nil {
+		return err
+	}
+	for i := range obj.Actions {
+		var err error
+		obj.Actions[i], err = mapDiscriminatorMyCartUpdateAction(obj.Actions[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MyCartUpdateItemShippingAddressAction implements the interface MyCartUpdateAction
 type MyCartUpdateItemShippingAddressAction struct {
 	Address *Address `json:"address"`
@@ -1107,7 +1134,8 @@ func (obj MyCustomerAddAddressAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerAddBillingAddressIDAction implements the interface MyCustomerUpdateAction
 type MyCustomerAddBillingAddressIDAction struct {
-	AddressID string `json:"addressId"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1121,7 +1149,8 @@ func (obj MyCustomerAddBillingAddressIDAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerAddShippingAddressIDAction implements the interface MyCustomerUpdateAction
 type MyCustomerAddShippingAddressIDAction struct {
-	AddressID string `json:"addressId"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1135,8 +1164,9 @@ func (obj MyCustomerAddShippingAddressIDAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerChangeAddressAction implements the interface MyCustomerUpdateAction
 type MyCustomerChangeAddressAction struct {
-	AddressID string   `json:"addressId"`
-	Address   *Address `json:"address"`
+	AddressKey string   `json:"addressKey,omitempty"`
+	AddressID  string   `json:"addressId,omitempty"`
+	Address    *Address `json:"address"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1183,7 +1213,8 @@ type MyCustomerDraft struct {
 
 // MyCustomerRemoveAddressAction implements the interface MyCustomerUpdateAction
 type MyCustomerRemoveAddressAction struct {
-	AddressID string `json:"addressId"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1197,7 +1228,8 @@ func (obj MyCustomerRemoveAddressAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerRemoveBillingAddressIDAction implements the interface MyCustomerUpdateAction
 type MyCustomerRemoveBillingAddressIDAction struct {
-	AddressID string `json:"addressId"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1211,7 +1243,8 @@ func (obj MyCustomerRemoveBillingAddressIDAction) MarshalJSON() ([]byte, error) 
 
 // MyCustomerRemoveShippingAddressIDAction implements the interface MyCustomerUpdateAction
 type MyCustomerRemoveShippingAddressIDAction struct {
-	AddressID string `json:"addressId"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1283,7 +1316,8 @@ func (obj MyCustomerSetDateOfBirthAction) MarshalJSON() ([]byte, error) {
 
 // MyCustomerSetDefaultBillingAddressAction implements the interface MyCustomerUpdateAction
 type MyCustomerSetDefaultBillingAddressAction struct {
-	AddressID string `json:"addressId,omitempty"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1297,7 +1331,8 @@ func (obj MyCustomerSetDefaultBillingAddressAction) MarshalJSON() ([]byte, error
 
 // MyCustomerSetDefaultShippingAddressAction implements the interface MyCustomerUpdateAction
 type MyCustomerSetDefaultShippingAddressAction struct {
-	AddressID string `json:"addressId,omitempty"`
+	AddressKey string `json:"addressKey,omitempty"`
+	AddressID  string `json:"addressId,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1405,6 +1440,30 @@ func (obj MyCustomerSetVatIDAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setVatId", Alias: (*Alias)(&obj)})
+}
+
+// MyCustomerUpdate is a standalone struct
+type MyCustomerUpdate struct {
+	Version int                      `json:"version"`
+	Actions []MyCustomerUpdateAction `json:"actions"`
+}
+
+// UnmarshalJSON override to deserialize correct attribute types based
+// on the discriminator value
+func (obj *MyCustomerUpdate) UnmarshalJSON(data []byte) error {
+	type Alias MyCustomerUpdate
+	if err := json.Unmarshal(data, (*Alias)(obj)); err != nil {
+		return err
+	}
+	for i := range obj.Actions {
+		var err error
+		obj.Actions[i], err = mapDiscriminatorMyCustomerUpdateAction(obj.Actions[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // MyLineItemDraft is a standalone struct

--- a/commercetools/types_message.go
+++ b/commercetools/types_message.go
@@ -106,6 +106,13 @@ func mapDiscriminatorMessage(input interface{}) (Message, error) {
 			return nil, err
 		}
 		return new, nil
+	case "CustomerPasswordUpdated":
+		new := CustomerPasswordUpdatedMessage{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "DeliveryAdded":
 		new := DeliveryAddedMessage{}
 		err := decodeStruct(input, &new)
@@ -503,6 +510,13 @@ func mapDiscriminatorMessage(input interface{}) (Message, error) {
 			return nil, err
 		}
 		return new, nil
+	case "ProductVariantAdded":
+		new := ProductVariantAddedMessage{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "ProductVariantDeleted":
 		new := ProductVariantDeletedMessage{}
 		err := decodeStruct(input, &new)
@@ -541,6 +555,13 @@ func mapDiscriminatorMessage(input interface{}) (Message, error) {
 			if err != nil {
 				return nil, err
 			}
+		}
+		return new, nil
+	case "ShoppingListStoreSet":
+		new := ShoppingListStoreSetMessage{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
 		}
 		return new, nil
 	}
@@ -640,6 +661,13 @@ func mapDiscriminatorMessagePayload(input interface{}) (MessagePayload, error) {
 		return new, nil
 	case "CustomerGroupSet":
 		new := CustomerGroupSetMessagePayload{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "CustomerPasswordUpdated":
+		new := CustomerPasswordUpdatedMessagePayload{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -1042,6 +1070,13 @@ func mapDiscriminatorMessagePayload(input interface{}) (MessagePayload, error) {
 			return nil, err
 		}
 		return new, nil
+	case "ProductVariantAdded":
+		new := ProductVariantAddedMessagePayload{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "ProductVariantDeleted":
 		new := ProductVariantDeletedMessagePayload{}
 		err := decodeStruct(input, &new)
@@ -1080,6 +1115,13 @@ func mapDiscriminatorMessagePayload(input interface{}) (MessagePayload, error) {
 			if err != nil {
 				return nil, err
 			}
+		}
+		return new, nil
+	case "ShoppingListStoreSet":
+		new := ShoppingListStoreSetMessagePayload{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
 		}
 		return new, nil
 	}
@@ -1137,6 +1179,7 @@ type CategorySlugChangedMessage struct {
 	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
 	CreatedAt                       time.Time                `json:"createdAt"`
 	Slug                            *LocalizedString         `json:"slug"`
+	OldSlug                         *LocalizedString         `json:"oldSlug,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1150,7 +1193,8 @@ func (obj CategorySlugChangedMessage) MarshalJSON() ([]byte, error) {
 
 // CategorySlugChangedMessagePayload implements the interface MessagePayload
 type CategorySlugChangedMessagePayload struct {
-	Slug *LocalizedString `json:"slug"`
+	Slug    *LocalizedString `json:"slug"`
+	OldSlug *LocalizedString `json:"oldSlug,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -1545,6 +1589,44 @@ func (obj CustomerGroupSetMessagePayload) MarshalJSON() ([]byte, error) {
 		Type string `json:"type"`
 		*Alias
 	}{Type: "CustomerGroupSet", Alias: (*Alias)(&obj)})
+}
+
+// CustomerPasswordUpdatedMessage implements the interface Message
+type CustomerPasswordUpdatedMessage struct {
+	Version                         int                      `json:"version"`
+	SequenceNumber                  int                      `json:"sequenceNumber"`
+	ResourceVersion                 int                      `json:"resourceVersion"`
+	ResourceUserProvidedIdentifiers *UserProvidedIdentifiers `json:"resourceUserProvidedIdentifiers,omitempty"`
+	Resource                        Reference                `json:"resource"`
+	LastModifiedBy                  *LastModifiedBy          `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt                  time.Time                `json:"lastModifiedAt"`
+	ID                              string                   `json:"id"`
+	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
+	CreatedAt                       time.Time                `json:"createdAt"`
+	Reset                           bool                     `json:"reset"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CustomerPasswordUpdatedMessage) MarshalJSON() ([]byte, error) {
+	type Alias CustomerPasswordUpdatedMessage
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "CustomerPasswordUpdated", Alias: (*Alias)(&obj)})
+}
+
+// CustomerPasswordUpdatedMessagePayload implements the interface MessagePayload
+type CustomerPasswordUpdatedMessagePayload struct {
+	Reset bool `json:"reset"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj CustomerPasswordUpdatedMessagePayload) MarshalJSON() ([]byte, error) {
+	type Alias CustomerPasswordUpdatedMessagePayload
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "CustomerPasswordUpdated", Alias: (*Alias)(&obj)})
 }
 
 // DeliveryAddedMessage implements the interface Message
@@ -3633,7 +3715,7 @@ type ProductPublishedMessage struct {
 	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
 	CreatedAt                       time.Time                `json:"createdAt"`
 	Scope                           ProductPublishScope      `json:"scope"`
-	RemovedImageUrls                []interface{}            `json:"removedImageUrls"`
+	RemovedImageUrls                []string                 `json:"removedImageUrls"`
 	ProductProjection               *ProductProjection       `json:"productProjection"`
 }
 
@@ -3649,7 +3731,7 @@ func (obj ProductPublishedMessage) MarshalJSON() ([]byte, error) {
 // ProductPublishedMessagePayload implements the interface MessagePayload
 type ProductPublishedMessagePayload struct {
 	Scope             ProductPublishScope `json:"scope"`
-	RemovedImageUrls  []interface{}       `json:"removedImageUrls"`
+	RemovedImageUrls  []string            `json:"removedImageUrls"`
 	ProductProjection *ProductProjection  `json:"productProjection"`
 }
 
@@ -3753,6 +3835,7 @@ type ProductSlugChangedMessage struct {
 	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
 	CreatedAt                       time.Time                `json:"createdAt"`
 	Slug                            *LocalizedString         `json:"slug"`
+	OldSlug                         *LocalizedString         `json:"oldSlug,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -3766,7 +3849,8 @@ func (obj ProductSlugChangedMessage) MarshalJSON() ([]byte, error) {
 
 // ProductSlugChangedMessagePayload implements the interface MessagePayload
 type ProductSlugChangedMessagePayload struct {
-	Slug *LocalizedString `json:"slug"`
+	Slug    *LocalizedString `json:"slug"`
+	OldSlug *LocalizedString `json:"oldSlug,omitempty"`
 }
 
 // MarshalJSON override to set the discriminator value
@@ -3851,6 +3935,46 @@ func (obj ProductUnpublishedMessagePayload) MarshalJSON() ([]byte, error) {
 		Type string `json:"type"`
 		*Alias
 	}{Type: "ProductUnpublished", Alias: (*Alias)(&obj)})
+}
+
+// ProductVariantAddedMessage implements the interface Message
+type ProductVariantAddedMessage struct {
+	Version                         int                      `json:"version"`
+	SequenceNumber                  int                      `json:"sequenceNumber"`
+	ResourceVersion                 int                      `json:"resourceVersion"`
+	ResourceUserProvidedIdentifiers *UserProvidedIdentifiers `json:"resourceUserProvidedIdentifiers,omitempty"`
+	Resource                        Reference                `json:"resource"`
+	LastModifiedBy                  *LastModifiedBy          `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt                  time.Time                `json:"lastModifiedAt"`
+	ID                              string                   `json:"id"`
+	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
+	CreatedAt                       time.Time                `json:"createdAt"`
+	Variant                         *ProductVariant          `json:"variant"`
+	Staged                          bool                     `json:"staged"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ProductVariantAddedMessage) MarshalJSON() ([]byte, error) {
+	type Alias ProductVariantAddedMessage
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "ProductVariantAdded", Alias: (*Alias)(&obj)})
+}
+
+// ProductVariantAddedMessagePayload implements the interface MessagePayload
+type ProductVariantAddedMessagePayload struct {
+	Variant *ProductVariant `json:"variant"`
+	Staged  bool            `json:"staged"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ProductVariantAddedMessagePayload) MarshalJSON() ([]byte, error) {
+	type Alias ProductVariantAddedMessagePayload
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "ProductVariantAdded", Alias: (*Alias)(&obj)})
 }
 
 // ProductVariantDeletedMessage implements the interface Message
@@ -4093,6 +4217,44 @@ func (obj *ReviewStateTransitionMessagePayload) UnmarshalJSON(data []byte) error
 	}
 
 	return nil
+}
+
+// ShoppingListStoreSetMessage implements the interface Message
+type ShoppingListStoreSetMessage struct {
+	Version                         int                      `json:"version"`
+	SequenceNumber                  int                      `json:"sequenceNumber"`
+	ResourceVersion                 int                      `json:"resourceVersion"`
+	ResourceUserProvidedIdentifiers *UserProvidedIdentifiers `json:"resourceUserProvidedIdentifiers,omitempty"`
+	Resource                        Reference                `json:"resource"`
+	LastModifiedBy                  *LastModifiedBy          `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt                  time.Time                `json:"lastModifiedAt"`
+	ID                              string                   `json:"id"`
+	CreatedBy                       *CreatedBy               `json:"createdBy,omitempty"`
+	CreatedAt                       time.Time                `json:"createdAt"`
+	Store                           *StoreKeyReference       `json:"store"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ShoppingListStoreSetMessage) MarshalJSON() ([]byte, error) {
+	type Alias ShoppingListStoreSetMessage
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "ShoppingListStoreSet", Alias: (*Alias)(&obj)})
+}
+
+// ShoppingListStoreSetMessagePayload implements the interface MessagePayload
+type ShoppingListStoreSetMessagePayload struct {
+	Store *StoreKeyReference `json:"store"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ShoppingListStoreSetMessagePayload) MarshalJSON() ([]byte, error) {
+	type Alias ShoppingListStoreSetMessagePayload
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{Type: "ShoppingListStoreSet", Alias: (*Alias)(&obj)})
 }
 
 // UserProvidedIdentifiers is a standalone struct

--- a/commercetools/types_order.go
+++ b/commercetools/types_order.go
@@ -185,6 +185,20 @@ func mapDiscriminatorOrderUpdateAction(input interface{}) (OrderUpdateAction, er
 			return nil, err
 		}
 		return new, nil
+	case "setBillingAddressCustomField":
+		new := OrderSetBillingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setBillingAddressCustomType":
+		new := OrderSetBillingAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setCustomField":
 		new := OrderSetCustomFieldAction{}
 		err := decodeStruct(input, &new)
@@ -241,8 +255,36 @@ func mapDiscriminatorOrderUpdateAction(input interface{}) (OrderUpdateAction, er
 			return nil, err
 		}
 		return new, nil
+	case "setDeliveryAddressCustomField":
+		new := OrderSetDeliveryAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setDeliveryAddressCustomType":
+		new := OrderSetDeliveryAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setDeliveryItems":
 		new := OrderSetDeliveryItemsAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomField":
+		new := OrderSetItemShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomType":
+		new := OrderSetItemShippingAddressCustomTypeAction{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -320,6 +362,20 @@ func mapDiscriminatorOrderUpdateAction(input interface{}) (OrderUpdateAction, er
 		return new, nil
 	case "setShippingAddress":
 		new := OrderSetShippingAddressAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomField":
+		new := OrderSetShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomType":
+		new := OrderSetShippingAddressCustomTypeAction{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -949,8 +1005,8 @@ type Delivery struct {
 
 // DeliveryItem is a standalone struct
 type DeliveryItem struct {
-	Quantity float64 `json:"quantity"`
-	ID       string  `json:"id"`
+	Quantity int    `json:"quantity"`
+	ID       string `json:"id"`
 }
 
 // DiscountedLineItemPriceDraft is a standalone struct
@@ -1198,7 +1254,8 @@ type OrderFromCartDraft struct {
 	PaymentState  PaymentState             `json:"paymentState,omitempty"`
 	OrderState    OrderState               `json:"orderState,omitempty"`
 	OrderNumber   string                   `json:"orderNumber,omitempty"`
-	ID            string                   `json:"id"`
+	ID            string                   `json:"id,omitempty"`
+	Cart          *CartResourceIdentifier  `json:"cart,omitempty"`
 }
 
 // OrderImportCustomLineItemStateAction implements the interface OrderUpdateAction
@@ -1366,6 +1423,36 @@ func (obj OrderSetBillingAddressAction) MarshalJSON() ([]byte, error) {
 	}{Action: "setBillingAddress", Alias: (*Alias)(&obj)})
 }
 
+// OrderSetBillingAddressCustomFieldAction implements the interface OrderUpdateAction
+type OrderSetBillingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetBillingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetBillingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetBillingAddressCustomTypeAction implements the interface OrderUpdateAction
+type OrderSetBillingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetBillingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetBillingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
 // OrderSetCustomFieldAction implements the interface OrderUpdateAction
 type OrderSetCustomFieldAction struct {
 	Value interface{} `json:"value,omitempty"`
@@ -1486,6 +1573,38 @@ func (obj OrderSetDeliveryAddressAction) MarshalJSON() ([]byte, error) {
 	}{Action: "setDeliveryAddress", Alias: (*Alias)(&obj)})
 }
 
+// OrderSetDeliveryAddressCustomFieldAction implements the interface OrderUpdateAction
+type OrderSetDeliveryAddressCustomFieldAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	DeliveryID string                  `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetDeliveryAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetDeliveryAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetDeliveryAddressCustomTypeAction implements the interface OrderUpdateAction
+type OrderSetDeliveryAddressCustomTypeAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	DeliveryID string      `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetDeliveryAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetDeliveryAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
 // OrderSetDeliveryItemsAction implements the interface OrderUpdateAction
 type OrderSetDeliveryItemsAction struct {
 	Items      []DeliveryItem `json:"items"`
@@ -1499,6 +1618,38 @@ func (obj OrderSetDeliveryItemsAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setDeliveryItems", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetItemShippingAddressCustomFieldAction implements the interface OrderUpdateAction
+type OrderSetItemShippingAddressCustomFieldAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	AddressKey string      `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetItemShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetItemShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetItemShippingAddressCustomTypeAction implements the interface OrderUpdateAction
+type OrderSetItemShippingAddressCustomTypeAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	AddressKey string                  `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetItemShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetItemShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // OrderSetLineItemCustomFieldAction implements the interface OrderUpdateAction
@@ -1663,6 +1814,36 @@ func (obj OrderSetShippingAddressAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setShippingAddress", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetShippingAddressCustomFieldAction implements the interface OrderUpdateAction
+type OrderSetShippingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderSetShippingAddressCustomTypeAction implements the interface OrderUpdateAction
+type OrderSetShippingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderSetShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderSetShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // OrderSetStoreAction implements the interface OrderUpdateAction

--- a/commercetools/types_order_edit.go
+++ b/commercetools/types_order_edit.go
@@ -87,6 +87,20 @@ func mapDiscriminatorOrderEditUpdateAction(input interface{}) (OrderEditUpdateAc
 			}
 		}
 		return new, nil
+	case "setBillingAddressCustomField":
+		new := OrderEditSetBillingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setBillingAddressCustomType":
+		new := OrderEditSetBillingAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setComment":
 		new := OrderEditSetCommentAction{}
 		err := decodeStruct(input, &new)
@@ -108,8 +122,50 @@ func mapDiscriminatorOrderEditUpdateAction(input interface{}) (OrderEditUpdateAc
 			return nil, err
 		}
 		return new, nil
+	case "setDeliveryAddressCustomField":
+		new := OrderEditSetDeliveryAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setDeliveryAddressCustomType":
+		new := OrderEditSetDeliveryAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomField":
+		new := OrderEditSetItemShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setItemShippingAddressCustomType":
+		new := OrderEditSetItemShippingAddressCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setKey":
 		new := OrderEditSetKeyAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomField":
+		new := OrderEditSetShippingAddressCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setShippingAddressCustomType":
+		new := OrderEditSetShippingAddressCustomTypeAction{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -368,6 +424,36 @@ func (obj OrderEditResourceIdentifier) MarshalJSON() ([]byte, error) {
 	}{TypeID: "order-edit", Alias: (*Alias)(&obj)})
 }
 
+// OrderEditSetBillingAddressCustomFieldAction implements the interface OrderEditUpdateAction
+type OrderEditSetBillingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetBillingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetBillingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetBillingAddressCustomTypeAction implements the interface OrderEditUpdateAction
+type OrderEditSetBillingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetBillingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetBillingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setBillingAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
 // OrderEditSetCommentAction implements the interface OrderEditUpdateAction
 type OrderEditSetCommentAction struct {
 	Comment string `json:"comment,omitempty"`
@@ -412,6 +498,70 @@ func (obj OrderEditSetCustomTypeAction) MarshalJSON() ([]byte, error) {
 	}{Action: "setCustomType", Alias: (*Alias)(&obj)})
 }
 
+// OrderEditSetDeliveryAddressCustomFieldAction implements the interface OrderEditUpdateAction
+type OrderEditSetDeliveryAddressCustomFieldAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	DeliveryID string                  `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetDeliveryAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetDeliveryAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetDeliveryAddressCustomTypeAction implements the interface OrderEditUpdateAction
+type OrderEditSetDeliveryAddressCustomTypeAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	DeliveryID string      `json:"deliveryId"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetDeliveryAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetDeliveryAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDeliveryAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetItemShippingAddressCustomFieldAction implements the interface OrderEditUpdateAction
+type OrderEditSetItemShippingAddressCustomFieldAction struct {
+	Value      interface{} `json:"value,omitempty"`
+	Name       string      `json:"name"`
+	AddressKey string      `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetItemShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetItemShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetItemShippingAddressCustomTypeAction implements the interface OrderEditUpdateAction
+type OrderEditSetItemShippingAddressCustomTypeAction struct {
+	Type       *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields     *FieldContainer         `json:"fields,omitempty"`
+	AddressKey string                  `json:"addressKey"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetItemShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetItemShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setItemShippingAddressCustomType", Alias: (*Alias)(&obj)})
+}
+
 // OrderEditSetKeyAction implements the interface OrderEditUpdateAction
 type OrderEditSetKeyAction struct {
 	Key string `json:"key,omitempty"`
@@ -424,6 +574,36 @@ func (obj OrderEditSetKeyAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setKey", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetShippingAddressCustomFieldAction implements the interface OrderEditUpdateAction
+type OrderEditSetShippingAddressCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetShippingAddressCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetShippingAddressCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomField", Alias: (*Alias)(&obj)})
+}
+
+// OrderEditSetShippingAddressCustomTypeAction implements the interface OrderEditUpdateAction
+type OrderEditSetShippingAddressCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj OrderEditSetShippingAddressCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias OrderEditSetShippingAddressCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setShippingAddressCustomType", Alias: (*Alias)(&obj)})
 }
 
 // OrderEditSetStagedActionsAction implements the interface OrderEditUpdateAction

--- a/commercetools/types_product.go
+++ b/commercetools/types_product.go
@@ -473,7 +473,7 @@ func (obj CustomTokenizer) MarshalJSON() ([]byte, error) {
 
 // FacetResultRange is a standalone struct
 type FacetResultRange struct {
-	Total        int     `json:"total"`
+	Total        float64 `json:"total"`
 	ToStr        string  `json:"toStr"`
 	To           float64 `json:"to"`
 	ProductCount int     `json:"productCount,omitempty"`
@@ -848,6 +848,7 @@ type ProductProjectionPagedSearchResponse struct {
 	Total   int                 `json:"total,omitempty"`
 	Results []ProductProjection `json:"results"`
 	Offset  int                 `json:"offset"`
+	Limit   int                 `json:"limit"`
 	Facets  *FacetResults       `json:"facets"`
 	Count   int                 `json:"count"`
 }

--- a/commercetools/types_shipping_method.go
+++ b/commercetools/types_shipping_method.go
@@ -81,6 +81,20 @@ func mapDiscriminatorShippingMethodUpdateAction(input interface{}) (ShippingMeth
 			return nil, err
 		}
 		return new, nil
+	case "setCustomField":
+		new := ShippingMethodSetCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setCustomType":
+		new := ShippingMethodSetCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setDescription":
 		new := ShippingMethodSetDescriptionAction{}
 		err := decodeStruct(input, &new)
@@ -221,6 +235,7 @@ type ShippingMethod struct {
 	IsDefault            bool                  `json:"isDefault"`
 	ID                   string                `json:"id"`
 	Description          string                `json:"description,omitempty"`
+	Custom               *CustomFields         `json:"custom,omitempty"`
 	CreatedBy            *CreatedBy            `json:"createdBy,omitempty"`
 	CreatedAt            time.Time             `json:"createdAt"`
 }
@@ -306,6 +321,7 @@ type ShippingMethodDraft struct {
 	Key                  string                         `json:"key,omitempty"`
 	IsDefault            bool                           `json:"isDefault"`
 	Description          string                         `json:"description,omitempty"`
+	Custom               *CustomFieldsDraft             `json:"custom,omitempty"`
 }
 
 // ShippingMethodPagedQueryResponse is a standalone struct
@@ -374,6 +390,36 @@ func (obj ShippingMethodResourceIdentifier) MarshalJSON() ([]byte, error) {
 		TypeID string `json:"typeId"`
 		*Alias
 	}{TypeID: "shipping-method", Alias: (*Alias)(&obj)})
+}
+
+// ShippingMethodSetCustomFieldAction implements the interface ShippingMethodUpdateAction
+type ShippingMethodSetCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ShippingMethodSetCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias ShippingMethodSetCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setCustomField", Alias: (*Alias)(&obj)})
+}
+
+// ShippingMethodSetCustomTypeAction implements the interface ShippingMethodUpdateAction
+type ShippingMethodSetCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields *FieldContainer         `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ShippingMethodSetCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias ShippingMethodSetCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setCustomType", Alias: (*Alias)(&obj)})
 }
 
 // ShippingMethodSetDescriptionAction implements the interface ShippingMethodUpdateAction

--- a/commercetools/types_shopping_list.go
+++ b/commercetools/types_shopping_list.go
@@ -162,6 +162,13 @@ func mapDiscriminatorShoppingListUpdateAction(input interface{}) (ShoppingListUp
 			return nil, err
 		}
 		return new, nil
+	case "setStore":
+		new := ShoppingListSetStoreAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setTextLineItemCustomField":
 		new := ShoppingListSetTextLineItemCustomFieldAction{}
 		err := decodeStruct(input, &new)
@@ -603,6 +610,20 @@ func (obj ShoppingListSetSlugAction) MarshalJSON() ([]byte, error) {
 		Action string `json:"action"`
 		*Alias
 	}{Action: "setSlug", Alias: (*Alias)(&obj)})
+}
+
+// ShoppingListSetStoreAction implements the interface ShoppingListUpdateAction
+type ShoppingListSetStoreAction struct {
+	Store *StoreResourceIdentifier `json:"store,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj ShoppingListSetStoreAction) MarshalJSON() ([]byte, error) {
+	type Alias ShoppingListSetStoreAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setStore", Alias: (*Alias)(&obj)})
 }
 
 // ShoppingListSetTextLineItemCustomFieldAction implements the interface ShoppingListUpdateAction

--- a/commercetools/types_store.go
+++ b/commercetools/types_store.go
@@ -22,6 +22,55 @@ func mapDiscriminatorStoreUpdateAction(input interface{}) (StoreUpdateAction, er
 		return nil, errors.New("Invalid data")
 	}
 	switch discriminator {
+	case "addDistributionChannel":
+		new := StoreAddDistributionChannelAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "addSupplyChannel":
+		new := StoreAddSupplyChannelAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "removeDistributionChannel":
+		new := StoreRemoveDistributionChannelAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "removeSupplyChannel":
+		new := StoreRemoveSupplyChannelAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setCustomField":
+		new := StoreSetCustomFieldAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setCustomType":
+		new := StoreSetCustomTypeAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
+	case "setDistributionChannels":
+		new := StoreSetDistributionChannelsAction{}
+		err := decodeStruct(input, &new)
+		if err != nil {
+			return nil, err
+		}
+		return new, nil
 	case "setLanguages":
 		new := StoreSetLanguagesAction{}
 		err := decodeStruct(input, &new)
@@ -36,43 +85,8 @@ func mapDiscriminatorStoreUpdateAction(input interface{}) (StoreUpdateAction, er
 			return nil, err
 		}
 		return new, nil
-	case "addDistributionChannel":
-		new := StoresAddDistributionChannelsAction{}
-		err := decodeStruct(input, &new)
-		if err != nil {
-			return nil, err
-		}
-		return new, nil
-	case "addSupplyChannel":
-		new := StoresAddSupplyChannelsAction{}
-		err := decodeStruct(input, &new)
-		if err != nil {
-			return nil, err
-		}
-		return new, nil
-	case "removeDistributionChannel":
-		new := StoresRemoveDistributionChannelsAction{}
-		err := decodeStruct(input, &new)
-		if err != nil {
-			return nil, err
-		}
-		return new, nil
-	case "removeSupplyChannel":
-		new := StoresRemoveSupplyChannelsAction{}
-		err := decodeStruct(input, &new)
-		if err != nil {
-			return nil, err
-		}
-		return new, nil
-	case "setDistributionChannels":
-		new := StoresSetDistributionChannelsAction{}
-		err := decodeStruct(input, &new)
-		if err != nil {
-			return nil, err
-		}
-		return new, nil
 	case "setSupplyChannels":
-		new := StoresSetSupplyChannelsAction{}
+		new := StoreSetSupplyChannelsAction{}
 		err := decodeStruct(input, &new)
 		if err != nil {
 			return nil, err
@@ -93,8 +107,37 @@ type Store struct {
 	Key                  string             `json:"key"`
 	ID                   string             `json:"id"`
 	DistributionChannels []ChannelReference `json:"distributionChannels"`
+	Custom               *CustomFields      `json:"custom,omitempty"`
 	CreatedBy            *CreatedBy         `json:"createdBy,omitempty"`
 	CreatedAt            time.Time          `json:"createdAt"`
+}
+
+// StoreAddDistributionChannelAction implements the interface StoreUpdateAction
+type StoreAddDistributionChannelAction struct {
+	DistributionChannel *ChannelResourceIdentifier `json:"distributionChannel"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreAddDistributionChannelAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreAddDistributionChannelAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "addDistributionChannel", Alias: (*Alias)(&obj)})
+}
+
+// StoreAddSupplyChannelAction implements the interface StoreUpdateAction
+type StoreAddSupplyChannelAction struct {
+	SupplyChannel *ChannelResourceIdentifier `json:"supplyChannel"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreAddSupplyChannelAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreAddSupplyChannelAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "addSupplyChannel", Alias: (*Alias)(&obj)})
 }
 
 // StoreDraft is a standalone struct
@@ -104,6 +147,7 @@ type StoreDraft struct {
 	Languages            []string                    `json:"languages,omitempty"`
 	Key                  string                      `json:"key"`
 	DistributionChannels []ChannelResourceIdentifier `json:"distributionChannels,omitempty"`
+	Custom               *CustomFieldsDraft          `json:"custom,omitempty"`
 }
 
 // StoreKeyReference implements the interface KeyReference
@@ -144,6 +188,34 @@ func (obj StoreReference) MarshalJSON() ([]byte, error) {
 	}{TypeID: "store", Alias: (*Alias)(&obj)})
 }
 
+// StoreRemoveDistributionChannelAction implements the interface StoreUpdateAction
+type StoreRemoveDistributionChannelAction struct {
+	DistributionChannel *ChannelResourceIdentifier `json:"distributionChannel"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreRemoveDistributionChannelAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreRemoveDistributionChannelAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "removeDistributionChannel", Alias: (*Alias)(&obj)})
+}
+
+// StoreRemoveSupplyChannelAction implements the interface StoreUpdateAction
+type StoreRemoveSupplyChannelAction struct {
+	SupplyChannel *ChannelResourceIdentifier `json:"supplyChannel"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreRemoveSupplyChannelAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreRemoveSupplyChannelAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "removeSupplyChannel", Alias: (*Alias)(&obj)})
+}
+
 // StoreResourceIdentifier implements the interface ResourceIdentifier
 type StoreResourceIdentifier struct {
 	Key string `json:"key,omitempty"`
@@ -157,6 +229,50 @@ func (obj StoreResourceIdentifier) MarshalJSON() ([]byte, error) {
 		TypeID string `json:"typeId"`
 		*Alias
 	}{TypeID: "store", Alias: (*Alias)(&obj)})
+}
+
+// StoreSetCustomFieldAction implements the interface StoreUpdateAction
+type StoreSetCustomFieldAction struct {
+	Value interface{} `json:"value,omitempty"`
+	Name  string      `json:"name"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreSetCustomFieldAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreSetCustomFieldAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setCustomField", Alias: (*Alias)(&obj)})
+}
+
+// StoreSetCustomTypeAction implements the interface StoreUpdateAction
+type StoreSetCustomTypeAction struct {
+	Type   *TypeResourceIdentifier `json:"type,omitempty"`
+	Fields interface{}             `json:"fields,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreSetCustomTypeAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreSetCustomTypeAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setCustomType", Alias: (*Alias)(&obj)})
+}
+
+// StoreSetDistributionChannelsAction implements the interface StoreUpdateAction
+type StoreSetDistributionChannelsAction struct {
+	DistributionChannels []ChannelResourceIdentifier `json:"distributionChannels,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreSetDistributionChannelsAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreSetDistributionChannelsAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setDistributionChannels", Alias: (*Alias)(&obj)})
 }
 
 // StoreSetLanguagesAction implements the interface StoreUpdateAction
@@ -187,6 +303,20 @@ func (obj StoreSetNameAction) MarshalJSON() ([]byte, error) {
 	}{Action: "setName", Alias: (*Alias)(&obj)})
 }
 
+// StoreSetSupplyChannelsAction implements the interface StoreUpdateAction
+type StoreSetSupplyChannelsAction struct {
+	SupplyChannels []ChannelResourceIdentifier `json:"supplyChannels,omitempty"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj StoreSetSupplyChannelsAction) MarshalJSON() ([]byte, error) {
+	type Alias StoreSetSupplyChannelsAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setSupplyChannels", Alias: (*Alias)(&obj)})
+}
+
 // StoreUpdate is a standalone struct
 type StoreUpdate struct {
 	Version int                 `json:"version"`
@@ -209,88 +339,4 @@ func (obj *StoreUpdate) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
-}
-
-// StoresAddDistributionChannelsAction implements the interface StoreUpdateAction
-type StoresAddDistributionChannelsAction struct {
-	DistributionChannel *ChannelResourceIdentifier `json:"distributionChannel"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresAddDistributionChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresAddDistributionChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "addDistributionChannel", Alias: (*Alias)(&obj)})
-}
-
-// StoresAddSupplyChannelsAction implements the interface StoreUpdateAction
-type StoresAddSupplyChannelsAction struct {
-	SupplyChannel *ChannelResourceIdentifier `json:"supplyChannel"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresAddSupplyChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresAddSupplyChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "addSupplyChannel", Alias: (*Alias)(&obj)})
-}
-
-// StoresRemoveDistributionChannelsAction implements the interface StoreUpdateAction
-type StoresRemoveDistributionChannelsAction struct {
-	DistributionChannel *ChannelResourceIdentifier `json:"distributionChannel"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresRemoveDistributionChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresRemoveDistributionChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "removeDistributionChannel", Alias: (*Alias)(&obj)})
-}
-
-// StoresRemoveSupplyChannelsAction implements the interface StoreUpdateAction
-type StoresRemoveSupplyChannelsAction struct {
-	SupplyChannel *ChannelResourceIdentifier `json:"supplyChannel"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresRemoveSupplyChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresRemoveSupplyChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "removeSupplyChannel", Alias: (*Alias)(&obj)})
-}
-
-// StoresSetDistributionChannelsAction implements the interface StoreUpdateAction
-type StoresSetDistributionChannelsAction struct {
-	DistributionChannels []ChannelResourceIdentifier `json:"distributionChannels,omitempty"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresSetDistributionChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresSetDistributionChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "setDistributionChannels", Alias: (*Alias)(&obj)})
-}
-
-// StoresSetSupplyChannelsAction implements the interface StoreUpdateAction
-type StoresSetSupplyChannelsAction struct {
-	SupplyChannels []ChannelResourceIdentifier `json:"supplyChannels,omitempty"`
-}
-
-// MarshalJSON override to set the discriminator value
-func (obj StoresSetSupplyChannelsAction) MarshalJSON() ([]byte, error) {
-	type Alias StoresSetSupplyChannelsAction
-	return json.Marshal(struct {
-		Action string `json:"action"`
-		*Alias
-	}{Action: "setSupplyChannels", Alias: (*Alias)(&obj)})
 }

--- a/commercetools/types_subscription.go
+++ b/commercetools/types_subscription.go
@@ -358,6 +358,7 @@ type ResourceDeletedDelivery struct {
 	ProjectKey                      string                   `json:"projectKey"`
 	Version                         int                      `json:"version"`
 	ModifiedAt                      time.Time                `json:"modifiedAt"`
+	DataErasure                     bool                     `json:"dataErasure"`
 }
 
 // MarshalJSON override to set the discriminator value

--- a/commercetools/types_type.go
+++ b/commercetools/types_type.go
@@ -13,6 +13,7 @@ type ResourceTypeID string
 
 // Enum values for ResourceTypeID
 const (
+	ResourceTypeIDAddress                     ResourceTypeID = "address"
 	ResourceTypeIDAsset                       ResourceTypeID = "asset"
 	ResourceTypeIDCategory                    ResourceTypeID = "category"
 	ResourceTypeIDChannel                     ResourceTypeID = "channel"
@@ -26,6 +27,7 @@ const (
 	ResourceTypeIDPayment                     ResourceTypeID = "payment"
 	ResourceTypeIDPaymentInterfaceInteraction ResourceTypeID = "payment-interface-interaction"
 	ResourceTypeIDReview                      ResourceTypeID = "review"
+	ResourceTypeIDShippingMethod              ResourceTypeID = "shipping-method"
 	ResourceTypeIDShoppingList                ResourceTypeID = "shopping-list"
 	ResourceTypeIDShoppingListTextLineItem    ResourceTypeID = "shopping-list-text-line-item"
 	ResourceTypeIDDiscountCode                ResourceTypeID = "discount-code"


### PR DESCRIPTION
While looking at implementing [Custom Fields to Shipping Methods](https://docs.commercetools.com/api/releases/2021-01-27-added-custom-fields-to-shipping-methods) in the [labd/terraform-provider-commercetools](https://github.com/labd/terraform-provider-commercetools) repo, I noticed few missing fields that weren't imported from [commercetools/commercetools-api-reference](https://github.com/commercetools/commercetools-api-reference/).

I took the lead and run the make generate command to pick-up the latest change, would that just work?
