### PR TITLE
query: Allow multiple expand parameters

### DIFF
--- a/commercetools/client_queryinput.go
+++ b/commercetools/client_queryinput.go
@@ -35,7 +35,7 @@ type QueryInput struct {
 	// use-case. Reference expansion can be used when creating, updating,
 	// querying, and deleting these resources.
 	// https://docs.commercetools.com/http-api.html#reference-expansion
-	Expand string
+	Expand []string
 
 	Limit  int
 	Offset int
@@ -52,8 +52,8 @@ func (qi QueryInput) toParams() (values url.Values) {
 		values.Add("sort", qi.Sort[i])
 	}
 
-	if qi.Expand != "" {
-		values.Set("expand", qi.Expand)
+	for i := range qi.Expand {
+		values.Add("expand", qi.Expand[i])
 	}
 
 	if qi.Limit != 0 {

--- a/commercetools/client_queryinput_test.go
+++ b/commercetools/client_queryinput_test.go
@@ -40,12 +40,12 @@ func TestQueryInput(t *testing.T) {
 		{
 			desc: "Expand",
 			input: &commercetools.QueryInput{
-				Expand: "taxCategory",
+				Expand: []string{"taxCategory", "categories[*]"},
 			},
 			query: url.Values{
-				"expand": []string{"taxCategory"},
+				"expand": []string{"taxCategory", "categories[*]"},
 			},
-			rawQuery: "expand=taxCategory",
+			rawQuery: "expand=taxCategory&expand=categories%5B%2A%5D",
 		},
 		{
 			desc: "Limit",


### PR DESCRIPTION
The expand can be given multiple times.
See https://docs.commercetools.com/api/general-concepts#reference-expansion for reference.
