### PR TITLE
query: Add extra arguments

### DIFF
--- a/commercetools/client_queryinput.go
+++ b/commercetools/client_queryinput.go
@@ -39,6 +39,9 @@ type QueryInput struct {
 
 	Limit  int
 	Offset int
+
+	// Extra query arguments.
+	Extra url.Values
 }
 
 func (qi QueryInput) toParams() (values url.Values) {
@@ -64,5 +67,8 @@ func (qi QueryInput) toParams() (values url.Values) {
 		values.Set("offset", strconv.Itoa(qi.Offset))
 	}
 
+	for k, v := range qi.Extra {
+		values[k] = v
+	}
 	return
 }

--- a/commercetools/client_queryinput_test.go
+++ b/commercetools/client_queryinput_test.go
@@ -67,6 +67,22 @@ func TestQueryInput(t *testing.T) {
 			},
 			rawQuery: "offset=20",
 		},
+		{
+			desc: "Extra",
+			input: &commercetools.QueryInput{
+				Limit:  23,
+				Offset: 42,
+				Extra: url.Values{
+					"staged": []string{"true"},
+				},
+			},
+			query: url.Values{
+				"limit":  []string{"23"},
+				"offset": []string{"42"},
+				"staged": []string{"true"},
+			},
+			rawQuery: "limit=23&offset=42&staged=true",
+		},
 	}
 
 	for _, tC := range testCases {


### PR DESCRIPTION
Allow QueryInput to pass arbitrary parameters to queries.

An example endpoint that takes more parameters is [product projections query](https://docs.commercetools.com/api/projects/productProjections#query-productprojections)
