### PR TITLE
Change return type of CustomerCreate

### DIFF
--- a/code-generate/parse_services.go
+++ b/code-generate/parse_services.go
@@ -230,6 +230,9 @@ func createDomainMethod(item yaml.MapItem, sd *ServiceDomain) *ServiceMethod {
 			ReturnType: sd.ResourceType,
 			Type:       "create",
 		}
+		if sd.ResourceDraft == "CustomerDraft" {
+			method.ReturnType = "CustomerSignInResult"
+		}
 	default:
 		if strings.HasPrefix(key, "/") {
 			method = createActionServiceMethods(key, value, sd)

--- a/commercetools/service_customer.go
+++ b/commercetools/service_customer.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 )
 
-// CustomerCreate creates a new instance of type Customer
-func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft, opts ...RequestOption) (result *Customer, err error) {
+// CustomerCreate creates a new instance of type CustomerSignInResult
+func (client *Client) CustomerCreate(ctx context.Context, draft *CustomerDraft, opts ...RequestOption) (result *CustomerSignInResult, err error) {
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)

--- a/commercetools/service_in_store.go
+++ b/commercetools/service_in_store.go
@@ -253,8 +253,8 @@ func (client *Client) StoreCartReplicate(ctx context.Context, storeKey string, v
 	return result, nil
 }
 
-// StoreCustomerCreate creates a new instance of type Customer
-func (client *Client) StoreCustomerCreate(ctx context.Context, storeKey string, draft *CustomerDraft, opts ...RequestOption) (result *Customer, err error) {
+// StoreCustomerCreate creates a new instance of type CustomerSignInResult
+func (client *Client) StoreCustomerCreate(ctx context.Context, storeKey string, draft *CustomerDraft, opts ...RequestOption) (result *CustomerSignInResult, err error) {
 	params := url.Values{}
 	for _, opt := range opts {
 		opt(&params)


### PR DESCRIPTION
Well, the Commercetools API is very, uh, special in many places. One of
these ugly special cases is **not** returning a Customer when creating a
customer...

Unfortunately this isn't a generic workaround, but it's the easiest and I didn't find other occurrences like these in the CT API (yet). 